### PR TITLE
Add Rack dependency to enforce old version in example Gemfile

### DIFF
--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -57,3 +57,4 @@ end
 
 gem 'openstudio-standards', '0.2.10'
 gem 'simplecov', github: 'NREL/simplecov'
+gem 'rack', '2.1.2'


### PR DESCRIPTION
Addresses #40 

This is a quick fix for Windows users. **Not** intended to be the permanent solution!

Use Rack < 2.2 to work with Ruby 2.2. When we stop requiring Ruby 2.2 we can remove this requirement as well.
I expect Rack to only be used by github_api, a dev dependency. Why Windows users are requiring this for normal operation is not yet understood.