### PR TITLE
Restore config settings to default

### DIFF
--- a/example_files/runner.conf
+++ b/example_files/runner.conf
@@ -1,7 +1,7 @@
 {
   "file_version": "0.1.0",
-  "max_datapoints": 1000,
-  "num_parallel": 1,
+  "max_datapoints": 1000000000,
+  "num_parallel": 2,
   "run_simulations": true,
   "verbose": false
 }


### PR DESCRIPTION
### Pull Request Description
Config file was accidentally merged with settings still tweaked for testing. This restores the config settings to match the default values in openstudio-extension https://github.com/NREL/openstudio-extension-gem/blob/develop/lib/openstudio/extension/runner_config.rb#L75-L83

### Checklist

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with ~develop~ master
