### PR TITLE
Creates empty project folder

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -201,7 +201,6 @@ module URBANopt
             # (https://github.com/urbanopt/urbanopt-example-geojson-project/pull/24 gets merged)
             # these files will change
             
-            config_file = "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/runner.conf"
             
             remote_mapper_files = [
                 "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/mappers/base_workflow.osw",
@@ -240,6 +239,12 @@ module URBANopt
                     "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/osm_building/9.osm"
                 ]
 
+                config_file = "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/runner.conf"
+                config_path, config_name = File.split(config_file)
+                config_download = open(config_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
+                IO.copy_stream(config_download, File.join(dir_name, config_name))
+
+                
                 # Download weather file to user's local machine
                 remote_weather_files.each do |weather_file|
                     weather_path, weather_name = File.split(weather_file)

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -268,13 +268,13 @@ module URBANopt
         puts "\nAn example FeatureFile is included: 'example_project.json'. You may place your own FeatureFile alongside the example."
         puts "Weather data is provided for the example FeatureFile. Additional weather data files may be downloaded from energyplus.net/weather for free"
         puts "If you use additional weather files, ensure they are added to the 'weather' directory. You will need to configure your mapper file and your osw file to use the desired weather file"
-        puts "Next, move inside your new folder ('cd <FolderYouJustCreated>') and create ScenarioFiles using this CLI: 'uo -m -f <FFP>'"
+        puts "Next, move inside your new folder ('cd <FolderYouJustCreated>') and create ScenarioFiles using this CLI call: 'uo -m -f <FFP>'"
     elsif @user_input[:project_folder] && @user_input[:empty_project_folder]
         create_project_folder(@user_input[:project_folder], empty_folder = true)
         puts "Add your FeatureFile in the Project directory you just created."
         puts "Add your weather data files in the Weather folder. They may be downloaded from energyplus.net/weather for free"
         puts "Add your OpenStudio models for Features in your Feature file, if any in the osm_building folder"
-        puts "Next, move inside your new folder ('cd <FolderYouJustCreated>') and create ScenarioFiles using this CLI: 'uo -m -f <FFP>'"
+        puts "Next, move inside your new folder ('cd <FolderYouJustCreated>') and create ScenarioFiles using this CLI call: 'uo -m -f <FFP>'"
     end
 
     if @user_input[:make_scenario_from]

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -45,16 +45,26 @@ module URBANopt
     # Set up user interface
     @user_input = {}
     the_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: uo [-pmradsfiv]\n" +
+        opts.banner = "Usage: uo [-pemradsfiv]\n" +
         "\n" +
         "URBANopt CLI\n" +
         "First create a project folder with -p, then run additional commands as desired\n" +
+        "Or create "
         "Additional config options can be set with the 'runner.conf' file inside your new project folder"
         opts.separator ""
 
         opts.on("-p", "--project_folder <DIR>",String, "Create project directory named <DIR> in your current folder\n" +
-            "                                     You must be insde the project directory you just created for all following commands to work") do |folder|
+            "                                     You must be inside the project directory you just created for all following commands to work") do |folder|
             @user_input[:project_folder] = folder
+        end
+
+        opts.on("-e", "--empty_project_folder", String, "Use with -p argument to create an empty project folder\n" +
+            "                                     Example: uo -e -p <DIR>\n" +
+            "                                     Then add your own Feature file in the project directory you created,\n" +
+            "                                     add Weather files in the weather folder and add OpenStudio models of Features \n" +
+            "                                     in the Feature File, if any in the osm_building folder \n" +
+            "                                     You must be inside the project directory you just created for all following commands to work") do
+            @user_input[:empty_project_folder] = "Create empty project folder"  # This text does not get displayed to the user
         end
         
         opts.on("-m", "--make_scenario", String, "Create ScenarioCSV files for each MapperFile using the Feature file path. Must specify -f argument\n" +
@@ -175,7 +185,7 @@ module URBANopt
     # 
     # Folder gets created in the current working directory
     # Includes weather for UO's example location, a base workflow file, and mapper files to show a baseline and a high-efficiency option.
-    def self.create_project_folder(dir_name)
+    def self.create_project_folder(dir_name, empty_folder = false)
         if Dir.exist?(dir_name)
             abort("ERROR:  there is already a directory here named #{dir_name}... aborting")
         else
@@ -188,65 +198,83 @@ module URBANopt
             weather_dir_abs_path = File.absolute_path(File.join(dir_name, 'weather/'))
             osm_dir_abs_path = File.absolute_path(File.join(dir_name, 'osm_building/'))
 
-            # FIXME: When residential hpxml flow is implemented (https://github.com/urbanopt/urbanopt-example-geojson-project/pull/24 gets merged) these files will change
+            # FIXME: When residential hpxml flow is implemented
+            # (https://github.com/urbanopt/urbanopt-example-geojson-project/pull/24 gets merged)
+            # these files will change
+            
             config_file = "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/runner.conf"
-
-            example_feature_file = "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/example_project.json"
-            example_gem_file = "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/Gemfile"
+            
             remote_mapper_files = [
                 "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/mappers/base_workflow.osw",
                 "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/mappers/Baseline.rb",
                 "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/mappers/HighEfficiency.rb",
             ]
-            remote_weather_files = [
-                "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw",
-                "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.ddy",
-                "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.stat",
-            ]
-
-            osm_files = [
-                "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/osm_building/7.osm",
-                "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/osm_building/8.osm",
-                "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/osm_building/9.osm"
-            ]
             
-            # Download files to user's local machine
+            example_gem_file = "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/Gemfile"
+            
+            # Download mapper files to user's local machine
             remote_mapper_files.each do |mapper_file|
                 mapper_path, mapper_name = File.split(mapper_file)
                 mapper_download = open(mapper_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
                 IO.copy_stream(mapper_download, File.join(mappers_dir_abs_path, mapper_name))
             end
-            remote_weather_files.each do |weather_file|
-                weather_path, weather_name = File.split(weather_file)
-                weather_download = open(weather_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
-                IO.copy_stream(weather_download, File.join(weather_dir_abs_path, weather_name))
-            end
-            osm_files.each do |osm_file|
-                osm_path, osm_name = File.split(osm_file)
-                osm_download = open(osm_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
-                IO.copy_stream(osm_download, File.join(osm_dir_abs_path, osm_name))
-            end
+
+            # Download gemfile to user's local machine
             gem_path, gem_name = File.split(example_gem_file)
             example_gem_download = open(example_gem_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
             IO.copy_stream(example_gem_download, File.join(dir_name, gem_name))
 
-            feature_path, feature_name = File.split(example_feature_file)
-            example_feature_download = open(example_feature_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
-            IO.copy_stream(example_feature_download, File.join(dir_name, feature_name))
+            #if argument for creating an empty folder is not added
+            if empty_folder == false
+                
+                example_feature_file = "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/example_project.json"
+            
+                remote_weather_files = [
+                    "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw",
+                    "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.ddy",
+                    "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.stat",
+                ]
 
-            config_path, config_name = File.split(config_file)
-            config_download = open(config_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
-            IO.copy_stream(config_download, File.join(dir_name, config_name))
+                osm_files = [
+                    "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/osm_building/7.osm",
+                    "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/osm_building/8.osm",
+                    "https://raw.githubusercontent.com/urbanopt/urbanopt-cli/master/example_files/osm_building/9.osm"
+                ]
+
+                # Download weather file to user's local machine
+                remote_weather_files.each do |weather_file|
+                    weather_path, weather_name = File.split(weather_file)
+                    weather_download = open(weather_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
+                    IO.copy_stream(weather_download, File.join(weather_dir_abs_path, weather_name))
+                end
+
+                osm_files.each do |osm_file|
+                    osm_path, osm_name = File.split(osm_file)
+                    osm_download = open(osm_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
+                    IO.copy_stream(osm_download, File.join(osm_dir_abs_path, osm_name))
+                end
+
+                feature_path, feature_name = File.split(example_feature_file)
+                example_feature_download = open(example_feature_file, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
+                IO.copy_stream(example_feature_download, File.join(dir_name, feature_name))
+
+            end
         end
     end
 
 
     # Perform CLI actions
-    if @user_input[:project_folder]
-        create_project_folder(@user_input[:project_folder])
+    if @user_input[:project_folder] && @user_input[:empty_project_folder].nil?
+        create_project_folder(@user_input[:project_folder], empty_folder = false)
         puts "\nAn example FeatureFile is included: 'example_project.json'. You may place your own FeatureFile alongside the example."
         puts "Weather data is provided for the example FeatureFile. Additional weather data files may be downloaded from energyplus.net/weather for free"
         puts "If you use additional weather files, ensure they are added to the 'weather' directory. You will need to configure your mapper file and your osw file to use the desired weather file"
+        puts "Next, move inside your new folder ('cd <FolderYouJustCreated>') and create ScenarioFiles using this CLI: 'uo -m -f <FFP>'"
+    elsif @user_input[:project_folder] && @user_input[:empty_project_folder]
+        create_project_folder(@user_input[:project_folder], empty_folder = true)
+        puts "Add your FeatureFile in the Project directory you just created."
+        puts "Add your weather data files in the Weather folder. They may be downloaded from energyplus.net/weather for free"
+        puts "Add your OpenStudio models for Features in your Feature file, if any in the osm_building folder"
         puts "Next, move inside your new folder ('cd <FolderYouJustCreated>') and create ScenarioFiles using this CLI: 'uo -m -f <FFP>'"
     end
 
@@ -267,6 +295,8 @@ module URBANopt
             puts "Done"
         end
     end
+
+
 
     if @user_input[:run_scenario]
         if @user_input[:scenario].nil?

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -49,7 +49,6 @@ module URBANopt
         "\n" +
         "URBANopt CLI\n" +
         "First create a project folder with -p, then run additional commands as desired\n" +
-        "Or create "
         "Additional config options can be set with the 'runner.conf' file inside your new project folder"
         opts.separator ""
 


### PR DESCRIPTION
### Addresses #63 

### Pull Request Description

Creates an empty base project folder when `-e` tag specified while creating project using `-p`. The project folder created does not include the feature file, weather files, and any openstudio models in osm_building.

### Checklist (Delete lines that don't apply)

- [ ] Documentation has been modified appropriately
- [x] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
