### PR TITLE
Add DSS post-processor

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -45,7 +45,7 @@ module URBANopt
     # Set up user interface
     @user_input = {}
     the_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: uo [-peomrgdsfiv]\n" +
+        opts.banner = "Usage: uo [-peomrgdsfitv]\n" +
         "\n" +
         "URBANopt CLI\n" +
         "First create a project folder with -p, then run additional commands as desired\n" +
@@ -366,6 +366,7 @@ module URBANopt
         
         scenario_result = URBANopt::Scenario::ScenarioDefaultPostProcessor.new(run_func()).run
         scenario_result.save
+        # FIXME: Remove this feature_reports block once urbanopt/urbanopt-scenario-gem#104 is merged
         # save feature reports 
         scenario_result.feature_reports.each do |feature_report|
             feature_report.save_feature_report()

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -349,12 +349,13 @@ module URBANopt
             puts "\nDone\n"
         elsif @user_input[:type] == 'opendss'
             puts "\nPost-processing OpenDSS results\n"
-            if File.directory?(File.join(@scenario_path, 'run', @scenario_name, 'opendss'))
+            opendss_folder = File.join(@scenario_path, 'run', @scenario_folder, 'opendss')
+            if File.directory?(opendss_folder)
                 opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result, opendss_results_dir_name = 'opendss')
                 opendss_post_processor.run
                 puts "\nDone\n"
             else
-                abort("No OpenDSS results available in folder '<project directory>/run/<scenario name>/opendss'")
+                abort("No OpenDSS results available in folder '#{opendss_folder}'")
             end
         elsif @user_input[:type] == 'reopt'
             puts "\nReopt post-processing not implemented yet\n"

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -45,7 +45,7 @@ module URBANopt
     # Set up user interface
     @user_input = {}
     the_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: uo [-pemrgdsfiv]\n" +
+        opts.banner = "Usage: uo [-pemrgdsfitv]\n" +
         "\n" +
         "URBANopt CLI\n" +
         "First create a project folder with -p, then run additional commands as desired\n" +

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -45,7 +45,7 @@ module URBANopt
     # Set up user interface
     @user_input = {}
     the_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: uo [-pemradsfiv]\n" +
+        opts.banner = "Usage: uo [-pemrgdsfiv]\n" +
         "\n" +
         "URBANopt CLI\n" +
         "First create a project folder with -p, then run additional commands as desired\n" +
@@ -78,9 +78,9 @@ module URBANopt
             @user_input[:run_scenario] = "Run simulations"  # This text does not get displayed to the user
         end
 
-        opts.on("-a", "--aggregate", String, "Aggregate individual feature results to scenario-level results. Must specify -s & -f arguments\n" +
-            "                                     Example: uo -a -s baseline_scenario.csv -f example_project.json") do
-            @user_input[:aggregate] = "Aggregate all features to a whole Scenario"  # This text does not get displayed to the user
+        opts.on("-g", "--gather", String, "group individual feature results to scenario-level results. Must specify -t, -s, & -f arguments\n" +
+            "                                     Example: uo -g -t default -s baseline_scenario.csv -f example_project.json") do
+            @user_input[:gather] = "Aggregate all features to a whole Scenario"  # This text does not get displayed to the user
         end
         
         opts.on("-d", "--delete_scenario", String, "Delete results from scenario. Must specify -s argument\n" +
@@ -98,6 +98,13 @@ module URBANopt
         
         opts.on("-i", "--feature_id <FID>", Integer, "Specify <FID> (Feature ID). Used as input for other commands") do |feature_id|
             @user_input[:feature_id] = feature_id
+        end
+
+        opts.on("-t", "--type <TYPE>", String, "Specify <TYPE> of post-processor to run:\n" +
+            "                                       default\n" +
+            "                                       reopt\n" +
+            "                                       opendss\n") do |type|
+            @user_input[:type] = type
         end
         
         opts.on("-v", "--version", "Show CLI version and exit") do
@@ -300,8 +307,6 @@ module URBANopt
         end
     end
 
-
-
     if @user_input[:run_scenario]
         if @user_input[:scenario].nil?
             abort("\nYou must provide '-s' flag and a valid path to a ScenarioFile!\n---\n\n")
@@ -322,7 +327,7 @@ module URBANopt
         puts "Done"
     end
 
-    if @user_input[:aggregate]
+    if @user_input[:gather]
         if @user_input[:scenario].nil?
             abort("\nYou must provide '-s' flag and a valid path to a ScenarioFile!\n---\n\n")
         end
@@ -333,13 +338,21 @@ module URBANopt
         @scenario_path, @scenario_name = File.split(@user_input[:scenario])
         @feature_path, @feature_name = File.split(@user_input[:feature])
         
-        puts "\nAggregating results across all features of #{@feature_name} according to '#{@scenario_name}'...\n"
         scenario_result = URBANopt::Scenario::ScenarioDefaultPostProcessor.new(run_func()).run
         scenario_result.save
-        
-        opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result, 'opendss')
-        opendss_post_processor.run
-        puts "Done"
+
+        if @user_input[:type] == 'default'
+            puts "\nDone\n"
+        elsif @user_input[:type] == 'opendss'
+            puts "\nPost-processing OpenDSS results\n"
+            opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result)
+            opendss_post_processor.run
+            puts "\nDone\n"
+        elsif @user_input[:type] == 'reopt'
+            puts "\nReopt post-processing not implemented yet\n"
+        else
+            abort("\nError: did not use type 'default', 'reopt', or 'opendss'. Aborting...\n")
+        end
     end
 
     if @user_input[:delete_scenario]

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -350,7 +350,7 @@ module URBANopt
         elsif @user_input[:type] == 'opendss'
             puts "\nPost-processing OpenDSS results\n"
             if File.directory?(File.join(@scenario_path, 'run', @scenario_name, 'opendss'))
-                opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result, opendss_results_dir_name = 'opendss's)
+                opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result, opendss_results_dir_name = 'opendss')
                 opendss_post_processor.run
                 puts "\nDone\n"
             else

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -366,7 +366,7 @@ module URBANopt
         
         scenario_result = URBANopt::Scenario::ScenarioDefaultPostProcessor.new(run_func()).run
         scenario_result.save
-        # FIXME: Remove this feature_reports block once urbanopt/urbanopt-scenario-gem#104 is merged
+        # FIXME: Remove this feature_reports block once urbanopt/urbanopt-scenario-gem#104 works as expected.
         # save feature reports 
         scenario_result.feature_reports.each do |feature_report|
             feature_report.save_feature_report()

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -340,14 +340,22 @@ module URBANopt
         
         scenario_result = URBANopt::Scenario::ScenarioDefaultPostProcessor.new(run_func()).run
         scenario_result.save
+        # save feature reports 
+        scenario_result.feature_reports.each do |feature_report|
+            feature_report.save_feature_report()
+        end
 
         if @user_input[:type] == 'default'
             puts "\nDone\n"
         elsif @user_input[:type] == 'opendss'
             puts "\nPost-processing OpenDSS results\n"
-            opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result)
-            opendss_post_processor.run
-            puts "\nDone\n"
+            if File.directory?(File.join(@scenario_path, 'run', @scenario_name, 'opendss'))
+                opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result, opendss_results_dir_name = 'opendss's)
+                opendss_post_processor.run
+                puts "\nDone\n"
+            else
+                abort("No OpenDSS results available in folder '<project directory>/run/<scenario name>/opendss'")
+            end
         elsif @user_input[:type] == 'reopt'
             puts "\nReopt post-processing not implemented yet\n"
         else

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -332,9 +332,13 @@ module URBANopt
         @scenario_folder = "#{@user_input[:scenario].split('.')[0].capitalize}"
         @scenario_path, @scenario_name = File.split(@user_input[:scenario])
         @feature_path, @feature_name = File.split(@user_input[:feature])
+        
         puts "\nAggregating results across all features of #{@feature_name} according to '#{@scenario_name}'...\n"
         scenario_result = URBANopt::Scenario::ScenarioDefaultPostProcessor.new(run_func()).run
         scenario_result.save
+        
+        opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new(scenario_result, 'opendss')
+        opendss_post_processor.run
         puts "Done"
     end
 


### PR DESCRIPTION
### Addresses #68 

### Pull Request Description

- Add call to OpenDSS post-processor
- Remove `uo -a` call to post-processor
- Create `uo -g` call to post-processor
- Implement new `type` flag for users to specify which kind of post-processor they want to run. Will always run the default (kinda in the background), which the dss and reopt post-processors depend on.

### Checklist

- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
