### PR TITLE
Put reopt dependency in gemspec, not Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,11 @@ else
   # temporary
   # gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
 end
+
+if allow_local && File.exist?('../urbanopt-reopt-gem')
+  gem 'urbanopt-reopt', path: '../urbanopt-reopt-gem'
+elsif allow_local
+  gem 'urbanopt-reopt', github: 'URBANopt/urbanopt-reopt-gem', branch: 'develop'
+else
+  gem 'urbanopt-reopt', '0.2.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 # simplecov has a dependency on native json gem, use fork that does not require this
 gem 'certified'
 gem 'simplecov', github: 'NREL/simplecov'
-gem 'urbanopt-reopt', '0.2.0'
 
 # Local gems are useful when developing and integrating the various dependencies.
 # To favor the use of local gems, set the following environment variable:

--- a/uo_cli.gemspec
+++ b/uo_cli.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   #   use specific versions of urbanopt and openstudio dependencies while under heavy development
   spec.add_dependency 'urbanopt-geojson', '0.2.0'
   spec.add_dependency 'urbanopt-scenario', '0.2.0'
+  spec.add_dependency 'urbanopt-reopt', '0.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'github_api', '~> 0.18'


### PR DESCRIPTION
### Addresses #85 

### Pull Request Description

Dependency on REopt needs to be in the gemspec file.

### Checklist

- [x] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop