### PR TITLE
REopt postprocessor error checking

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -367,8 +367,9 @@ module URBANopt
       end
 
       valid_postprocessors = ['default', 'reopt-scenario', 'reopt-feature', 'opendss']
-      # Abort if <type> is nil or not in valid list
-      if @user_input[:type].nil? || valid_postprocessors.none? { |needle| @user_input[:type].include? needle }
+      # Abort if <type> is not a valid postprocessor
+      # FIXME: If -t is called but no value is entered, the CLI will incorrectly show the error as coming from the -s call
+      if !valid_postprocessors.include?(@user_input[:type])
         abort("\nYou must provide '-t' flag and a valid Gather type!\n" \
             "Valid types include: #{valid_postprocessors}\n---\n\n")
       end

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe URBANopt::CLI do
       expect { system("#{call_cli} -g -t foobar -s #{test_scenario} -f #{test_feature}") }
         .to output(a_string_including('valid Gather type!'))
         .to_stderr_from_any_process
+      expect { system("#{call_cli} -g -t reopt-scenariot -s #{test_scenario} -f #{test_feature}") }
+        .to output(a_string_including('valid Gather type!'))
+        .to_stderr_from_any_process
     end
 
     it 'post-processes a scenario' do


### PR DESCRIPTION
### Addresses #96 

### Pull Request Description

Simplify and improve error checking for user-input postprocessor types. Previously would not catch strings that included valid types plus more characters. It is now the way it should always have been done: simpler, and the postprocessor type must match exactly.

One issue I noticed that this doesn't fix: If the user enters `-t` and doesn't enter anything at all, the CLI throws an error that looks like it's coming from the `-s` call, which is incorrect. I'm not sure how to fix that. At least it still throws a graceful error, and the user can at least see that they did not enter anything after `-t`, even though they will be misled by the emphasis on `-s`.

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
