### PR TITLE
More appropriate post-processor test

### DIFF
--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -126,11 +126,17 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'post-processor exits gracefully if given an invalid type' do
+      # Type is totally random
       expect { system("#{call_cli} process --foobar --scenario #{test_scenario} --feature #{test_feature}") }
         .to output(a_string_including("unknown argument '--foobar'"))
         .to_stderr_from_any_process
+        # Type is valid, but with extra characters
       expect { system("#{call_cli} process --reopt-scenariot --scenario #{test_scenario} --feature #{test_feature}") }
         .to output(a_string_including("unknown argument '--reopt-scenariot'"))
+        .to_stderr_from_any_process
+        # Type would be valid if not missing characters
+      expect { system("#{call_cli} process --reopt-scenari --scenario #{test_scenario} --feature #{test_feature}") }
+        .to output(a_string_including("unknown argument '--reopt-scenari'"))
         .to_stderr_from_any_process
     end
 
@@ -141,8 +147,12 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'post-processes a scenario' do
+      filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
       system("#{call_cli} process --default --scenario #{test_scenario} --feature #{test_feature}")
-      expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv'))).to be true
+      expect( `wc -l < #{filename}`.to_i ).to be > 2
+      # If the run fails, the post-processor will still create the default_scenario_report file, just empty.
+      # This checks to see if that file contains more than 2 lines.
+      # This situation may only arise in the test suite, but this is still a more informative test.
     end
 
     it 'reopt post-processes a scenario' do


### PR DESCRIPTION
### Addresses #[issue number here]

### Pull Request Description

Test for default post-processor was possible to pass even when it shouldn't. This is a better way to test that gets closer to testing the desired behavior.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [ ] This branch is up-to-date with develop
