### PR TITLE
Integrate ditto-reader/opendss into workflow

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -501,10 +501,10 @@ module URBANopt
         feature_list = Pathname.new(run_dir).children.select(&:directory?)
         first_feature = File.basename(feature_list[0])
         if not File.exist?(File.join(run_dir, first_feature, 'eplusout.sql'))
-          abort("\nERROR: URBANopt simulations are required before using opendss. Please run simulations and try again.\n")
+          abort("\nERROR: URBANopt simulations are required before using opendss. Please run and process simulations, then try again.\n")
         end
       rescue Errno::ENOENT  # Same abort message if there is no run_dir
-        abort("\nERROR: URBANopt simulations are required before using opendss. Please run simulations and try again.\n")
+        abort("\nERROR: URBANopt simulations are required before using opendss. Please run and process simulations, then try again.\n")
       end
 
       # TODO: make this work for virtualenv

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -597,6 +597,7 @@ module URBANopt
       default_post_processor = URBANopt::Scenario::ScenarioDefaultPostProcessor.new(run_func)
       scenario_report = default_post_processor.run
       scenario_report.save
+      scenario_report.feature_reports.each(&:save_feature_report)
       if @opthash.subopts[:default] == true
         puts "\nDone\n"
       elsif @opthash.subopts[:opendss] == true

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -393,48 +393,36 @@ module URBANopt
     def self.check_python
       results = { python: false, message: '' }
       puts 'Checking system.....'
-      # determine platform
-      if OS.windows?
-        # check
-        puts '...Windows system found'
-
-      elsif OS.posix?
-        # check
-        # puts "...Posix system found"
-
-        stdout, stderr, status = Open3.capture3('python -V')
-        if stderr && !stderr == ''
-          # error
-          results[:message] = "ERROR: #{stderr}"
-          puts results[:message]
-          return results
-        end
-
-        # check version
-        stdout.slice! 'Python '
-        if stdout[0].to_i == 2 || (stdout[0].to_i == 3 && stdout[2].to_i < 7)
-          # global python version is not 3.7+
-          results[:message] = "ERROR: Python version must be at least 3.7.  Found python with version #{stdout}."
-          puts results[:message]
-          return results
-        else
-          puts "...Python >= 3.7 found (#{stdout.chomp})"
-        end
-
-        # check pip
-        stdout, stderr, status = Open3.capture3('pip -V')
-        if stderr && !stderr == ''
-          # error
-          results[:message] = "ERROR finding pip: #{stderr}"
-          puts results[:message]
-          return results
-        else
-          puts '...pip found'
-        end
-
-      else
-        results[:message] = 'ERROR: Invalid operating system or unable to determine operating system'
+      
+      # platform agnostic
+      stdout, stderr, status = Open3.capture3('python -V')
+      if stderr && !stderr == ''
+        # error
+        results[:message] = "ERROR: #{stderr}"
+        puts results[:message]
         return results
+      end
+
+      # check version
+      stdout.slice! 'Python '
+      if stdout[0].to_i == 2 || (stdout[0].to_i == 3 && stdout[2].to_i < 7)
+        # global python version is not 3.7+
+        results[:message] = "ERROR: Python version must be at least 3.7.  Found python with version #{stdout}."
+        puts results[:message]
+        return results
+      else
+        puts "...Python >= 3.7 found (#{stdout.chomp})"
+      end
+
+      # check pip
+      stdout, stderr, status = Open3.capture3('pip -V')
+      if stderr && !stderr == ''
+        # error
+        results[:message] = "ERROR finding pip: #{stderr}"
+        puts results[:message]
+        return results
+      else
+        puts '...pip found'
       end
 
       # all good

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -1,5 +1,3 @@
-require 'open3'
-
 RSpec.describe URBANopt::CLI do
   test_directory = File.join('spec', 'test_directory')
   test_scenario = File.join(test_directory, 'two_building_scenario.csv')
@@ -129,16 +127,10 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'checks for python from opendss command' do
-      # For now just see if it checks for python
-      stdout, stderr, status = Open3.capture3("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}")
-      puts "THE STDOUT:"
-      puts stdout
-      expect(stdout).to include("Checking system.....")
-      expect(stdout).to include("Python")
-
-      # expect { system("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}") }
-      #   .to output(a_string_including("Python"))
-      #   .to_stdout_from_any_process
+      # for now just check that it does the system check
+      expect { system("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}") }
+        .to output(a_string_including("Checking system....."))
+        .to_stdout_from_any_process
     end
 
     it 'post-processor exits gracefully if given an invalid type' do

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -125,16 +125,23 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '3', 'finished.job'))).to be false
     end
 
+    it 'checks for python from opendss command' do
+      # For now just see if it checks for python
+      expect { system("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}") }
+        .to output(a_string_including("Python"))
+        .to_stdout_from_any_process
+    end
+
     it 'post-processor exits gracefully if given an invalid type' do
       # Type is totally random
       expect { system("#{call_cli} process --foobar --scenario #{test_scenario} --feature #{test_feature}") }
         .to output(a_string_including("unknown argument '--foobar'"))
         .to_stderr_from_any_process
-        # Type is valid, but with extra characters
+      # Type is valid, but with extra characters
       expect { system("#{call_cli} process --reopt-scenariot --scenario #{test_scenario} --feature #{test_feature}") }
         .to output(a_string_including("unknown argument '--reopt-scenariot'"))
         .to_stderr_from_any_process
-        # Type would be valid if not missing characters
+      # Type would be valid if not missing characters
       expect { system("#{call_cli} process --reopt-scenari --scenario #{test_scenario} --feature #{test_feature}") }
         .to output(a_string_including("unknown argument '--reopt-scenari'"))
         .to_stderr_from_any_process
@@ -149,7 +156,7 @@ RSpec.describe URBANopt::CLI do
     it 'post-processes a scenario' do
       filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
       system("#{call_cli} process --default --scenario #{test_scenario} --feature #{test_feature}")
-      expect( `wc -l < #{filename}`.to_i ).to be > 2
+      expect(`wc -l < #{filename}`.to_i).to be > 2
       # If the run fails, the post-processor will still create the default_scenario_report file, just empty.
       # This checks to see if that file contains more than 2 lines.
       # This situation may only arise in the test suite, but this is still a more informative test.

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -1,3 +1,4 @@
+require 'open3'
 
 RSpec.describe URBANopt::CLI do
   test_directory = File.join('spec', 'test_directory')
@@ -129,9 +130,15 @@ RSpec.describe URBANopt::CLI do
 
     it 'checks for python from opendss command' do
       # For now just see if it checks for python
-      expect { system("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}") }
-        .to output(a_string_including("Python"))
-        .to_stdout_from_any_process
+      stdout, stderr, status = Open3.capture3("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}")
+      puts "THE STDOUT:"
+      puts stdout
+      expect(stdout).to include("Checking system.....")
+      expect(stdout).to include("Python")
+
+      # expect { system("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}") }
+      #   .to output(a_string_including("Python"))
+      #   .to_stdout_from_any_process
     end
 
     it 'post-processor exits gracefully if given an invalid type' do

--- a/uo_cli.gemspec
+++ b/uo_cli.gemspec
@@ -33,15 +33,14 @@ Gem::Specification.new do |spec|
 
   #   use specific versions of urbanopt and openstudio dependencies while under heavy development
   spec.add_dependency 'optimist'
+  spec.add_dependency 'os', '~> 1.1.1'
+  spec.add_dependency 'pycall', '1.2.1'
   spec.add_dependency 'urbanopt-geojson', '~> 0.3.0'
   spec.add_dependency 'urbanopt-reopt', '~> 0.3.0'
   spec.add_dependency 'urbanopt-scenario', '~> 0.3.0'
-  spec.add_dependency 'pycall', '1.2.1'
-  spec.add_dependency 'os', '~> 1.1.1'
-  
+
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
-
 end

--- a/uo_cli.gemspec
+++ b/uo_cli.gemspec
@@ -36,9 +36,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'urbanopt-geojson', '~> 0.3.0'
   spec.add_dependency 'urbanopt-reopt', '~> 0.3.0'
   spec.add_dependency 'urbanopt-scenario', '~> 0.3.0'
-
+  spec.add_dependency 'pycall', '1.2.1'
+  spec.add_dependency 'os', '~> 1.1.1'
+  
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
+
 end

--- a/uo_cli.gemspec
+++ b/uo_cli.gemspec
@@ -37,10 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'urbanopt-geojson', '~> 0.3.0'
   spec.add_runtime_dependency 'urbanopt-reopt', '~> 0.3.0'
   spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.1'
-  spec.add_runtime_dependency 'urbanopt-scenario', '~> 0.3.0'
+  spec.add_runtime_dependency 'urbanopt-scenario', '~> 0.3'
+  spec.add_runtime_dependency 'pycall', '1.3.1'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'rubocop', '~> 0.54.0'
+  spec.add_development_dependency 'rubocop', '~> 0.54'
 end


### PR DESCRIPTION
### Addresses #119 

### Pull Request Description
Adds the ability to run opendss workflow with the CLI.  Checks that a suitable version of python is installed and that the urbanopt-ditto-reader package is installed.  Runs the python workflow directly from the CLI via the pycall gem.

