### PR TITLE
add call to save scenario results in db file

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -146,7 +146,7 @@ module URBANopt
           opt :scenario, "\nSelect which scenario to optimize", default: 'baseline_scenario.csv', required: true
 
           opt :feature, "\nSelect which FeatureFile to use", default: 'example_project.json', required: true
-          
+
           opt :visualize, "\nVisualize results for default post-processing\n" \
 
         end
@@ -438,6 +438,7 @@ module URBANopt
       default_post_processor = URBANopt::Scenario::ScenarioDefaultPostProcessor.new(run_func)
       scenario_report = default_post_processor.run
       scenario_report.save
+      default_post_processor.create_scenario_db_file
       if @opthash.subopts[:default] == true
         puts "\nDone\n"
       elsif @opthash.subopts[:opendss] == true

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -148,8 +148,10 @@ RSpec.describe URBANopt::CLI do
 
     it 'post-processes a scenario' do
       filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
+      db_filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.db')
       system("#{call_cli} process --default --scenario #{test_scenario} --feature #{test_feature}")
       expect( `wc -l < #{filename}`.to_i ).to be > 2
+      expect( `wc -l < #{db_filename}`.to_i ).to be > 20
       # If the run fails, the post-processor will still create the default_scenario_report file, just empty.
       # This checks to see if that file contains more than 2 lines.
       # This situation may only arise in the test suite, but this is still a more informative test.


### PR DESCRIPTION
### Addresses #49 

### Pull Request Description

Adds a call to a new scenario-gem method during post-processing to save results as a db so they can be queried with sql.

For local testing, adjust Gemfile to point to the appropriate branch of scenario-gem until the new version is released (currently `db` branch). Jenkins postprocessing tests fail due to this.

### Checklist (Delete lines that don't apply)

- [ ] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
