### PR TITLE
Saving a database file is now optional

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -187,7 +187,7 @@ module URBANopt
           'Example: uo process --reopt-feature'
 
           opt :with_database, "\nInclude a sql database output of post-processed results\n" \
-          'Example: uo process --default --database'
+          'Example: uo process --default --with_database'
 
           opt :scenario, "\nSelect which scenario to optimize", default: 'baseline_scenario.csv', required: true
 

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -186,6 +186,9 @@ module URBANopt
           opt :reopt_feature, "\nOptimize for each building individually with REopt\n" \
           'Example: uo process --reopt-feature'
 
+          opt :with_database, "\nInclude a sql database output of post-processed results\n" \
+          'Example: uo process --default --database'
+
           opt :scenario, "\nSelect which scenario to optimize", default: 'baseline_scenario.csv', required: true
 
           opt :feature, "\nSelect which FeatureFile to use", default: 'example_project.json', required: true
@@ -682,7 +685,11 @@ module URBANopt
       scenario_report = default_post_processor.run
       scenario_report.save
       scenario_report.feature_reports.each(&:save_feature_report)
-      default_post_processor.create_scenario_db_file
+
+      if @opthash.subopts[:with_database] == true
+        default_post_processor.create_scenario_db_file
+      end
+
       if @opthash.subopts[:default] == true
         puts "\nDone\n"
         results << { "process_type": 'default', "status": 'Complete', "timestamp": Time.now.strftime('%Y-%m-%dT%k:%M:%S.%L') }

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -187,7 +187,7 @@ module URBANopt
           'Example: uo process --reopt-feature'
 
           opt :with_database, "\nInclude a sql database output of post-processed results\n" \
-          'Example: uo process --default --with_database'
+          'Example: uo process --default --with-database'
 
           opt :scenario, "\nSelect which scenario to optimize", default: 'baseline_scenario.csv', required: true
 

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '3', 'finished.job'))).to be false
     end
 
-    xit 'runs a 2 building scenario with residential and commercial buildings' do
+    it 'runs a 2 building scenario with residential and commercial buildings' do
       system("#{call_cli} create --project-folder #{test_directory_res} --combined")
       system("cp #{File.join('spec', 'spec_files', 'two_building_res.csv')} #{test_scenario_res}")
 
@@ -181,7 +181,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory_res, 'run', 'two_building_res', '16', 'finished.job'))).to be true
     end
 
-    xit 'runs a 2 building scenario using create bar geometry method' do
+    it 'runs a 2 building scenario using create bar geometry method' do
       # Copy create bar mapper
       system("cp #{File.join('example_files', 'mappers', 'CreateBar.rb')} #{File.join(test_directory, 'mappers', 'CreateBar.rb')}")
       # Copy osw file
@@ -192,7 +192,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_create_bar', '1', 'finished.job'))).to be true
     end
 
-    xit 'runs a 2 building scenario using floorspace geometry method' do
+    it 'runs a 2 building scenario using floorspace geometry method' do
       # Copy floorspace mapper
       system("cp #{File.join('example_files', 'mappers', 'Floorspace.rb')} #{File.join(test_directory, 'mappers', 'Floorspace.rb')}")
       # Copy osw file
@@ -209,7 +209,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_floorspace', '7', 'finished.job'))).to be true
     end
 
-    xit 'runs a scenario when called with reopt' do
+    it 'runs a scenario when called with reopt' do
       # Copy in a scenario file with only the first 2 buildings in it
       system("cp #{File.join('spec', 'spec_files', 'REopt_scenario.csv')} #{test_reopt_scenario}")
       # Copy in reopt folder
@@ -266,20 +266,20 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'process_status.json'))).to be true
     end
 
-    xit 'reopt post-processes a scenario' do
+    it 'reopt post-processes a scenario' do
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'scenario_optimization.json'))).to be false
       system("#{call_cli} process --reopt-scenario --scenario #{test_reopt_scenario} --feature #{test_feature}")
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'scenario_optimization.json'))).to be true
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'process_status.json'))).to be true
     end
 
-    xit 'reopt post-processes each feature' do
+    it 'reopt post-processes each feature' do
       system("#{call_cli} process --reopt-feature --scenario #{test_reopt_scenario} --feature #{test_feature}")
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'feature_optimization.csv'))).to be true
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'process_status.json'))).to be true
     end
 
-    xit 'opendss post-processes a scenario' do
+    it 'opendss post-processes a scenario' do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'opendss'))).to be false
       system("cp -R #{File.join('spec', 'spec_files', 'opendss')} #{File.join(test_directory, 'run', 'two_building_scenario', 'opendss')}")
       system("#{call_cli} process --opendss --scenario #{test_scenario} --feature #{test_feature}")
@@ -316,7 +316,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'feature_comparison.html'))).to be true
     end
 
-    xit 'deletes a scenario' do
+    it 'deletes a scenario' do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '1', 'data_point_out.json'))).to be true
       system("#{call_cli} delete --scenario #{test_scenario}")
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '1', 'data_point_out.json'))).to be false

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '3', 'finished.job'))).to be false
     end
 
-    it 'runs a 2 building scenario with residential and commercial buildings' do
+    xit 'runs a 2 building scenario with residential and commercial buildings' do
       system("#{call_cli} create --project-folder #{test_directory_res} --combined")
       system("cp #{File.join('spec', 'spec_files', 'two_building_res.csv')} #{test_scenario_res}")
 
@@ -181,7 +181,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory_res, 'run', 'two_building_res', '16', 'finished.job'))).to be true
     end
 
-    it 'runs a 2 building scenario using create bar geometry method' do
+    xit 'runs a 2 building scenario using create bar geometry method' do
       # Copy create bar mapper
       system("cp #{File.join('example_files', 'mappers', 'CreateBar.rb')} #{File.join(test_directory, 'mappers', 'CreateBar.rb')}")
       # Copy osw file
@@ -192,7 +192,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_create_bar', '1', 'finished.job'))).to be true
     end
 
-    it 'runs a 2 building scenario using floorspace geometry method' do
+    xit 'runs a 2 building scenario using floorspace geometry method' do
       # Copy floorspace mapper
       system("cp #{File.join('example_files', 'mappers', 'Floorspace.rb')} #{File.join(test_directory, 'mappers', 'Floorspace.rb')}")
       # Copy osw file
@@ -209,7 +209,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_floorspace', '7', 'finished.job'))).to be true
     end
 
-    it 'runs a scenario when called with reopt' do
+    xit 'runs a scenario when called with reopt' do
       # Copy in a scenario file with only the first 2 buildings in it
       system("cp #{File.join('spec', 'spec_files', 'REopt_scenario.csv')} #{test_reopt_scenario}")
       # Copy in reopt folder
@@ -254,24 +254,32 @@ RSpec.describe URBANopt::CLI do
       system("#{call_cli} process --default --scenario #{test_scenario} --feature #{test_feature}")
       filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
       expect(`wc -l < #{filename}`.to_i).to be > 2
+      expect(File.exist?(db_filename)).to be false
+      expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'process_status.json'))).to be true
+    end
+
+    it 'saves post-process output as a database file' do
+      filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
+      db_filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.db')
+      system("#{call_cli} process --default --with-database --scenario #{test_scenario} --feature #{test_feature}")
       expect(`wc -l < #{db_filename}`.to_i).to be > 20
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'process_status.json'))).to be true
     end
 
-    it 'reopt post-processes a scenario' do
+    xit 'reopt post-processes a scenario' do
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'scenario_optimization.json'))).to be false
       system("#{call_cli} process --reopt-scenario --scenario #{test_reopt_scenario} --feature #{test_feature}")
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'scenario_optimization.json'))).to be true
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'process_status.json'))).to be true
     end
 
-    it 'reopt post-processes each feature' do
+    xit 'reopt post-processes each feature' do
       system("#{call_cli} process --reopt-feature --scenario #{test_reopt_scenario} --feature #{test_feature}")
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'feature_optimization.csv'))).to be true
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', 'process_status.json'))).to be true
     end
 
-    it 'opendss post-processes a scenario' do
+    xit 'opendss post-processes a scenario' do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'opendss'))).to be false
       system("cp -R #{File.join('spec', 'spec_files', 'opendss')} #{File.join(test_directory, 'run', 'two_building_scenario', 'opendss')}")
       system("#{call_cli} process --opendss --scenario #{test_scenario} --feature #{test_feature}")
@@ -308,7 +316,7 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'feature_comparison.html'))).to be true
     end
 
-    it 'deletes a scenario' do
+    xit 'deletes a scenario' do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '1', 'data_point_out.json'))).to be true
       system("#{call_cli} delete --scenario #{test_scenario}")
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '1', 'data_point_out.json'))).to be false


### PR DESCRIPTION
### Resolves #151 

### Pull Request Description

Makes saving to a db file optional with a flag in the CLI

### Checklist

- [x] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
