### PR TITLE
Pin dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,9 +34,9 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # end
 
 # if allow_local && File.exist?('../urbanopt-scenario-gem')
-#   gem 'urbanopt-scenario', path: '../urbanopt-scenario-gem'
+  # gem 'urbanopt-scenario', path: '../urbanopt-scenario-gem'
 # elsif allow_local
-#   gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
+  gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'pin-dependencies'
 # end
 
 # if allow_local && File.exist?('../urbanopt-geojson-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-scenario-gem')
   # gem 'urbanopt-scenario', path: '../urbanopt-scenario-gem'
 # elsif allow_local
-  gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'pin-dependencies'
+  gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
 # end
 
 # if allow_local && File.exist?('../urbanopt-geojson-gem')

--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -31,7 +31,7 @@ if allow_local && File.exist?('../openstudio-common-measures-gem')
 elsif allow_local
   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'develop'
 else
-  gem 'openstudio-common-measures', '~> 0.2.0'
+  gem 'openstudio-common-measures', '0.2.0'
 end
 
 if allow_local && File.exist?('../openstudio-model-articulation-gem')

--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -39,7 +39,7 @@ if allow_local && File.exist?('../openstudio-model-articulation-gem')
 elsif allow_local
   gem 'openstudio-model-articulation', github: 'NREL/openstudio-model-articulation-gem', branch: 'develop'
 else
-  gem 'openstudio-model-articulation', '~> 0.2.0'
+  gem 'openstudio-model-articulation', '0.2.0'
 end
 
 if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')

--- a/example_files/example_project.json
+++ b/example_files/example_project.json
@@ -33,7 +33,7 @@
         "end_date": "2017-12-31T07:00:00.000Z",
         "cec_climate_zone": null,
         "climate_zone": "6A",
-        "default_template": "90.1-2013",      
+        "default_template": "90.1-2013",
         "import_surrounding_buildings_as_shading": null,
         "surface_elevation": null,
         "tariff_filename": null,
@@ -45,8 +45,8 @@
         "coordinates": [
           -78.84948467732347,
           42.81677154451123
-        ] 
-      }      
+        ]
+      }
     },
 
     {
@@ -56,6 +56,7 @@
         "name": "Mixed_use 1",
         "type": "Building",
         "building_type": "Mixed use",
+        "system_type": "VAV district chilled water with district hot water reheat",
         "floor_area": 752184,
         "footprint_area": 188046,
         "number_of_stories": 4,
@@ -116,6 +117,7 @@
         "name": "Restaurant 1",
         "type": "Building",
         "building_type": "Food service",
+        "system_type": "VAV district chilled water with district hot water reheat",
         "floor_area": 22313,
         "footprint_area": 22313,
         "number_of_stories": 1
@@ -238,7 +240,7 @@
         "building_type": "Food service",
         "floor_area": 8804,
         "footprint_area": 8804,
-        "number_of_stories": 1        
+        "number_of_stories": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -278,7 +280,7 @@
         "building_type": "Food service",
         "floor_area": 10689,
         "footprint_area": 10689,
-        "number_of_stories": 1        
+        "number_of_stories": 1
       },
       "geometry": {
         "type": "Polygon",
@@ -392,9 +394,9 @@
             ]
           ]
         ]
-      }      
+      }
     },
-    
+
     {
       "type": "Feature",
       "properties": {
@@ -449,7 +451,7 @@
         ]
       }
     },
-    
+
     {
       "type": "Feature",
       "properties": {
@@ -505,7 +507,7 @@
         ]
       }
     },
-    
+
     {
       "type": "Feature",
       "properties": {
@@ -545,7 +547,7 @@
         ]
       }
     },
-    
+
     {"type": "Feature",
       "properties": {
         "id": "12",
@@ -582,9 +584,9 @@
             ]
           ]
         ]
-      }     
+      }
     },
-    
+
     {
       "type": "Feature",
       "properties": {
@@ -622,7 +624,7 @@
             ]
           ]
         ]
-      }      
+      }
     }
   ]
 }

--- a/example_files/example_project.json
+++ b/example_files/example_project.json
@@ -33,7 +33,7 @@
         "end_date": "2017-12-31T07:00:00.000Z",
         "cec_climate_zone": null,
         "climate_zone": "6A",
-        "default_template": "90.1-2013",
+        "default_template": "90.1-2013",      
         "import_surrounding_buildings_as_shading": null,
         "surface_elevation": null,
         "tariff_filename": null,
@@ -45,8 +45,8 @@
         "coordinates": [
           -78.84948467732347,
           42.81677154451123
-        ]
-      }
+        ] 
+      }      
     },
 
     {
@@ -56,7 +56,6 @@
         "name": "Mixed_use 1",
         "type": "Building",
         "building_type": "Mixed use",
-        "system_type": "VAV district chilled water with district hot water reheat",
         "floor_area": 752184,
         "footprint_area": 188046,
         "number_of_stories": 4,
@@ -117,7 +116,6 @@
         "name": "Restaurant 1",
         "type": "Building",
         "building_type": "Food service",
-        "system_type": "VAV district chilled water with district hot water reheat",
         "floor_area": 22313,
         "footprint_area": 22313,
         "number_of_stories": 1
@@ -240,7 +238,7 @@
         "building_type": "Food service",
         "floor_area": 8804,
         "footprint_area": 8804,
-        "number_of_stories": 1
+        "number_of_stories": 1        
       },
       "geometry": {
         "type": "Polygon",
@@ -280,7 +278,7 @@
         "building_type": "Food service",
         "floor_area": 10689,
         "footprint_area": 10689,
-        "number_of_stories": 1
+        "number_of_stories": 1        
       },
       "geometry": {
         "type": "Polygon",
@@ -394,9 +392,9 @@
             ]
           ]
         ]
-      }
+      }      
     },
-
+    
     {
       "type": "Feature",
       "properties": {
@@ -451,7 +449,7 @@
         ]
       }
     },
-
+    
     {
       "type": "Feature",
       "properties": {
@@ -507,7 +505,7 @@
         ]
       }
     },
-
+    
     {
       "type": "Feature",
       "properties": {
@@ -547,7 +545,7 @@
         ]
       }
     },
-
+    
     {"type": "Feature",
       "properties": {
         "id": "12",
@@ -584,9 +582,9 @@
             ]
           ]
         ]
-      }
+      }     
     },
-
+    
     {
       "type": "Feature",
       "properties": {
@@ -624,7 +622,7 @@
             ]
           ]
         ]
-      }
+      }      
     }
   ]
 }

--- a/uo_cli.gemspec
+++ b/uo_cli.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'urbanopt-geojson', '~> 0.4.0'
   spec.add_runtime_dependency 'urbanopt-reopt', '~> 0.4.0'
   spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.2.0'
-  spec.add_runtime_dependency 'urbanopt-scenario', '~> 0.4.2'
+  # spec.add_runtime_dependency 'urbanopt-scenario', '~> 0.4.2'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
### Resolves #153 

### Pull Request Description

Pin example_project gemfile dependencies `openstudio-common-measures` and `openstudio-model-articulation` to version 0.2.0. Version 0.2.1 included breaking changes that we'll adopt fairly soon, just not yet.
- Includes temporary gemspec/gemfile changes to point to scenario-gem branch that includes the same dependency changes as in the example_project gemfile here.

### Checklist (Delete lines that don't apply)

- [ ] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
