### PR TITLE
Example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # rspec test folder
 spec/test_directory
 spec/test_directory_res
+spec/test_directory_elec
 
 Gemfile.lock
 .rubocop*

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@
 .vscode/
 .idea/
 
-# rbenv virtualenv management file
+# virtualenv management
 .ruby-version
+.python-version
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-scenario-gem')
 #  gem 'urbanopt-scenario', path: '../urbanopt-scenario-gem'
 # elsif allow_local
-   gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
+  #  gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
 # end
 
 # if allow_local && File.exist?('../urbanopt-geojson-gem')
@@ -60,5 +60,5 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-reporting-gem')
   # gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
 # elsif allow_local
-  gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
+  # gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
 # end

--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -79,5 +79,5 @@ if allow_local && File.exists?('../urbanopt-reporting-gem')
 elsif allow_local
   gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
 else
-  gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
+  gem 'urbanopt-reporting', '~> 0.3.6'
 end

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -396,6 +396,7 @@ module URBANopt
 
               # copy feature file
               FileUtils.cp(File.join(path_item, 'example_project.json'), dir_name)
+              FileUtils.cp(File.join(path_item, 'example_project_with_electric_network.json'), dir_name)
 
               # copy osm
               FileUtils.cp(File.join(path_item, 'osm_building/7.osm'), File.join(dir_name, 'osm_building'))

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -692,7 +692,7 @@ module URBANopt
           ditto_cli_addition += " --equipment #{@opthash.subopts[:equipment]}"
         end
         if @opthash.subopts[:time_points]
-          ditto_cli_addition += " --time_points #{opthash.subopts[:time_points]}"
+          ditto_cli_addition += " --time_points #{@opthash.subopts[:time_points]}"
         end
       else
         abort("\nCommand must include ScenarioFile & FeatureFile, or a config file that specifies both. Please try again")

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -675,7 +675,7 @@ module URBANopt
           abort("ERROR: URBANopt simulations are required before using opendss. Please run and process simulations, then try again.\n")
         end
       rescue Errno::ENOENT # Same abort message if there is no run_dir
-        abort("ERROR: URBANopt simulations are required before using opendss. Please run and process simulations, then try again. cowabunga\n")
+        abort("ERROR: URBANopt simulations are required before using opendss. Please run and process simulations, then try again.\n")
       end
 
       # We're calling the python cli that gets installed when the user installs ditto-reader.

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -654,8 +654,10 @@ module URBANopt
         abort("\nERROR: URBANopt simulations are required before using opendss. Please run and process simulations, then try again.\n")
       end
 
-      # We're calling the python cli that gets installed when the user installs ditto-reader. Haaaaaaaacky!
-      system("uo_cli run-opendss -s #{@opthash.subopts[:scenario]} -f #{@opthash.subopts[:feature]}")
+      # We're calling the python cli that gets installed when the user installs ditto-reader.
+      # If ditto-reader is installed into a venv (recommended), that venv must be activated for this to work.
+      # Haaaaaaaacky!
+      system("ditto_reader_cli run-opendss -s #{@opthash.subopts[:scenario]} -f #{@opthash.subopts[:feature]}")
     end
 
     # Post-process the scenario

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -170,8 +170,19 @@ module URBANopt
           opt :equipment, "\nRun OpenDSS simulations using <equipmentfile>. If not specified, the electrical_database.json from urbanopt-ditto-reader will be used.\n" \
           'Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json', type: String, short: :e
 
-          opt :time_points, "\nUse a specific number of time-points in the OpenDSS simulation.\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --time_points 24", type: Integer, short: :t
+          opt :timestep, "\nNumber of minutes per timestep in the OpenDSS simulation.\n" \
+          "Optional, defaults to analog of simulation timestep, set in the FeatureFile" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --timestep 15", type: Integer, short: :t
+
+          opt :start_time, "\nBeginning of the period for OpenDSS analysis" \
+          "Optional, defaults to beginning of simulation time" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start_time '2017/01/15 01:00:00'" \
+          "Ensure you have quotes around the timestamp, to allow for the space between date & time.", type: String
+
+          opt :end_time, "\End of the period for OpenDSS analysis" \
+          "Optional, defaults to beginning of simulation time" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end_time '2017/01/16 01:00:00'" \
+          "Ensure you have quotes around the timestamp, to allow for the space between date & time.", type: String
 
           opt :reopt, "\nRun with additional REopt functionality.\n" \
           "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --reopt", short: :r
@@ -691,8 +702,14 @@ module URBANopt
         if @opthash.subopts[:equipment]
           ditto_cli_addition += " --equipment #{@opthash.subopts[:equipment]}"
         end
-        if @opthash.subopts[:time_points]
-          ditto_cli_addition += " --time_points #{@opthash.subopts[:time_points]}"
+        if @opthash.subopts[:timestep]
+          ditto_cli_addition += " --timestep #{@opthash.subopts[:timestep]}"
+        end
+        if @opthash.subopts[:start_time]
+          ditto_cli_addition += " --start_time #{@opthash.subopts[:start_time]}"
+        end
+        if @opthash.subopts[:end_time]
+          ditto_cli_addition += " --end_time #{@opthash.subopts[:end_time]}"
         end
       else
         abort("\nCommand must include ScenarioFile & FeatureFile, or a config file that specifies both. Please try again")

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -657,7 +657,12 @@ module URBANopt
       # We're calling the python cli that gets installed when the user installs ditto-reader.
       # If ditto-reader is installed into a venv (recommended), that venv must be activated for this to work.
       # Haaaaaaaacky!
-      system("ditto_reader_cli run-opendss -s #{@opthash.subopts[:scenario]} -f #{@opthash.subopts[:feature]}")
+      begin
+        system("ditto_reader_cli run-opendss -s #{@opthash.subopts[:scenario]} -f #{@opthash.subopts[:feature]}")
+      rescue FileNotFoundError
+        abort("\nMust post-process results before running opendss. We recommend --default." \
+        "Once opendss is run, you may then 'process --opendss'")
+      end
     end
 
     # Post-process the scenario

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -654,36 +654,8 @@ module URBANopt
         abort("\nERROR: URBANopt simulations are required before using opendss. Please run and process simulations, then try again.\n")
       end
 
-      # TODO: make this work for virtualenv
-      # TODO: document adding PYTHON env var
-
-      # create config hash
-      config = {}
-
-      config['use_reopt'] = @opthash.subopts[:reopt] == true
-      config['urbanopt_scenario'] = run_dir
-      config['geojson_file'] = featurefile
-      if @opthash.subopts[:equipment]
-        config['equipment_file'] = @opthash.subopts[:equipment].to_s
-      end
-      config['opendss_folder'] = File.join(config['urbanopt_scenario'], 'opendss')
-
-      # TODO: allow users to specify ditto install location?
-      # Currently using ditto within the urbanopt-ditto-reader install
-
-      # run ditto_reader
-      pyfrom 'urbanopt_ditto_reader', import: 'UrbanoptDittoReader'
-
-      begin
-        pconf = PyCall::Dict.new(config)
-        r = UrbanoptDittoReader.new(pconf)
-        r.run
-      rescue StandardError => e
-        abort("\nOpenDSS run did not complete successfully: #{e.message}")
-      end
-
-      puts "\nDone. Results located in #{config['opendss_folder']}\n"
-
+      # We're calling the python cli that gets installed when the user installs ditto-reader. Haaaaaaaacky!
+      system("uo_cli run-opendss -s #{@opthash.subopts[:scenario]} -f #{@opthash.subopts[:feature]}")
     end
 
     # Post-process the scenario

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -500,7 +500,7 @@ module URBANopt
       puts 'Checking system.....'
 
       # platform agnostic
-      stdout, stderr, status = Open3.capture3('python -V')
+      stdout, stderr, status = Open3.capture3('python3 -V')
       if stderr && !stderr == ''
         # error
         results[:message] = "ERROR: #{stderr}"
@@ -509,7 +509,7 @@ module URBANopt
       end
 
       # check version
-      stdout.slice! 'Python '
+      stdout.slice! 'Python3 '
       if stdout[0].to_i == 2 || (stdout[0].to_i == 3 && stdout[2].to_i < 7)
         # global python version is not 3.7+
         results[:message] = "ERROR: Python version must be at least 3.7.  Found python with version #{stdout}."
@@ -520,7 +520,7 @@ module URBANopt
       end
 
       # check pip
-      stdout, stderr, status = Open3.capture3('pip -V')
+      stdout, stderr, status = Open3.capture3('pip3 -V')
       if stderr && !stderr == ''
         # error
         results[:message] = "ERROR finding pip: #{stderr}"
@@ -541,7 +541,7 @@ module URBANopt
 
       puts 'Checking for urbanopt-ditto-reader...'
 
-      stdout, stderr, status = Open3.capture3('pip list')
+      stdout, stderr, status = Open3.capture3('pip3 list')
       if stderr && !stderr == ''
         # error
         results[:message] = 'ERROR running pip list'

--- a/lib/uo_cli/version.rb
+++ b/lib/uo_cli/version.rb
@@ -30,6 +30,6 @@
 
 module URBANopt
   module CLI
-    VERSION = '0.5.0'.freeze
+    VERSION = '0.5.1'.freeze
   end
 end

--- a/spec/spec_files/electrical_scenario.csv
+++ b/spec/spec_files/electrical_scenario.csv
@@ -1,0 +1,14 @@
+Feature Id,Feature Name,Mapper Class
+1,Mixed_use 1,URBANopt::Scenario::BaselineMapper
+2,Restaurant 1,URBANopt::Scenario::BaselineMapper
+3,Restaurant 10,URBANopt::Scenario::BaselineMapper
+4,Restaurant 12,URBANopt::Scenario::BaselineMapper
+5,District Office 1,URBANopt::Scenario::BaselineMapper
+6,District Office 2,URBANopt::Scenario::BaselineMapper
+7,Office 1,URBANopt::Scenario::BaselineMapper
+8,Hospital 1,URBANopt::Scenario::BaselineMapper
+9,Hospital 2,URBANopt::Scenario::BaselineMapper
+10,Mixed use 2,URBANopt::Scenario::BaselineMapper
+11,Restaurant 13,URBANopt::Scenario::BaselineMapper
+12,Mall 1,URBANopt::Scenario::BaselineMapper
+13,Hotel 1,URBANopt::Scenario::BaselineMapper

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe URBANopt::CLI do
   test_scenario = File.join(test_directory, 'two_building_scenario.csv')
   test_scenario_res = File.join(test_directory_res, 'two_building_res.csv')
   test_reopt_scenario = File.join(test_directory, 'REopt_scenario.csv')
+  test_scenario_elec = File.join(test_directory, 'electrical_scenario.csv')
   test_feature = File.join(test_directory, 'example_project.json')
   test_feature_res = File.join(test_directory_res, 'example_project_combined.json')
+  test_feature_elec = File.join(test_directory, 'example_project_with_electric_network.json')
   test_validate_bounds = File.join(test_directory_res, 'out_of_bounds_validation.yaml')
   call_cli = "bundle exec uo"
 
@@ -91,11 +93,17 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'creates an example project directory for combined residential and commercial workflow' do
-      system("#{call_cli} create --project-folder #{test_directory} --combined")
-      expect(File.exist?(File.join(test_directory, 'mappers/residential'))).to be true
-      expect(File.exist?(File.join(test_directory, 'example_project_combined.json'))).to be true
-      expect(File.exist?(File.join(test_directory, 'measures'))).to be true
-      expect(File.exist?(File.join(test_directory, 'resources'))).to be true
+      delete_directory_or_file(test_directory_res)
+      system("#{call_cli} create --project-folder #{test_directory_res} --combined")
+      expect(File.exist?(File.join(test_directory_res, 'mappers/residential'))).to be true
+      expect(File.exist?(test_feature_res)).to be true
+      expect(File.exist?(File.join(test_directory_res, 'measures'))).to be true
+      expect(File.exist?(File.join(test_directory_res, 'resources'))).to be true
+    end
+
+    it 'creates an example project directory with electrical network properties' do
+      system("#{call_cli} create --project-folder #{test_directory}")
+      expect(File.exist?(test_feature_elec)).to be true
     end
 
     it 'creates an empty project directory' do
@@ -213,6 +221,12 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_ev_scenario', '2', 'finished.job'))).to be true
     end
 
+    it 'runs an electrical network scenario' do
+      system("cp #{File.join('spec', 'spec_files', 'electrical_scenario.csv')} #{test_scenario_elec}")
+      system("#{call_cli} run --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
+      expect(File.exist?(File.join(test_directory, 'run', 'electrical_scenario', '13', 'finished.job'))).to be true
+    end
+
     it 'runs a scenario when called with reopt' do
       system("cp #{File.join('spec', 'spec_files', 'REopt_scenario.csv')} #{test_reopt_scenario}")
       # Copy in reopt folder
@@ -221,13 +235,6 @@ RSpec.describe URBANopt::CLI do
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', '5', 'finished.job'))).to be true
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', '2', 'finished.job'))).to be true
       expect(File.exist?(File.join(test_directory, 'run', 'reopt_scenario', '3', 'finished.job'))).to be false
-    end
-
-    it 'checks for python from opendss command' do
-      # for now just check that it does the system check
-      expect { system("#{call_cli} opendss --scenario #{test_scenario} --feature #{test_feature}") }
-        .to output(a_string_including('Checking system.....'))
-        .to_stdout_from_any_process
     end
 
     it 'post-processor closes gracefully if given an invalid type' do
@@ -252,11 +259,16 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'default post-processes a scenario' do
-      filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
+      test_scenario_report = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
       system("#{call_cli} process --default --scenario #{test_scenario} --feature #{test_feature}")
-      filename = File.join(test_directory, 'run', 'two_building_scenario', 'default_scenario_report.csv')
-      expect(`wc -l < #{filename}`.to_i).to be > 2
+      expect(`wc -l < #{test_scenario_report}`.to_i).to be > 2
       expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'process_status.json'))).to be true
+    end
+
+    it 'successfully gets results from the opendss cli' do
+      system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
+      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
+      expect(File.exist?(File.join(test_directory, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
     end
 
     it 'saves post-process output as a database file' do

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -31,14 +31,15 @@
 RSpec.describe URBANopt::CLI do
   test_directory = File.join('spec', 'test_directory')
   test_directory_res = File.join('spec', 'test_directory_res')
+  test_directory_elec = File.join('spec', 'test_directory_elec')
   test_scenario = File.join(test_directory, 'two_building_scenario.csv')
   test_scenario_res = File.join(test_directory_res, 'two_building_res.csv')
   test_reopt_scenario = File.join(test_directory, 'REopt_scenario.csv')
-  test_scenario_elec = File.join(test_directory, 'electrical_scenario.csv')
+  test_scenario_elec = File.join(test_directory_elec, 'electrical_scenario.csv')
   test_ev_scenario = File.join(test_directory, 'two_building_ev_scenario.csv')
   test_feature = File.join(test_directory, 'example_project.json')
   test_feature_res = File.join(test_directory_res, 'example_project_combined.json')
-  test_feature_elec = File.join(test_directory, 'example_project_with_electric_network.json')
+  test_feature_elec = File.join(test_directory_elec, 'example_project_with_electric_network.json')
   test_validate_bounds = File.join(test_directory_res, 'out_of_bounds_validation.yaml')
   call_cli = "bundle exec uo"
 
@@ -103,7 +104,7 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'creates an example project directory with electrical network properties' do
-      system("#{call_cli} create --project-folder #{test_directory}")
+      system("#{call_cli} create --project-folder #{test_directory} --electric")
       expect(File.exist?(test_feature_elec)).to be true
     end
 
@@ -170,10 +171,12 @@ RSpec.describe URBANopt::CLI do
 
   context 'Run and work with a small simulation' do
     before :all do
-      delete_directory_or_file(test_directory)
-      delete_directory_or_file(test_directory_res)
-      system("#{call_cli} create --project-folder #{test_directory}")
-      system("#{call_cli} create --project-folder #{test_directory_res} --combined")
+      # delete_directory_or_file(test_directory)
+      # delete_directory_or_file(test_directory_res)
+      # delete_directory_or_file(test_directory_elec)
+      # system("#{call_cli} create --project-folder #{test_directory}")
+      # system("#{call_cli} create --project-folder #{test_directory_res} --combined")
+      # system("#{call_cli} create --project-folder #{test_directory_elec} --electric")
     end
 
     it 'runs a 2 building scenario using default geometry method' do
@@ -225,7 +228,7 @@ RSpec.describe URBANopt::CLI do
     it 'runs an electrical network scenario' do
       system("cp #{File.join('spec', 'spec_files', 'electrical_scenario.csv')} #{test_scenario_elec}")
       system("#{call_cli} run --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-      expect(File.exist?(File.join(test_directory, 'run', 'electrical_scenario', '13', 'finished.job'))).to be true
+      expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', '13', 'finished.job'))).to be true
     end
 
     it 'runs a scenario when called with reopt' do
@@ -269,7 +272,7 @@ RSpec.describe URBANopt::CLI do
     it 'successfully gets results from the opendss cli' do
       system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
       system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-      expect(File.exist?(File.join(test_directory, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
+      expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
     end
 
     it 'saves post-process output as a database file' do
@@ -292,11 +295,10 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'opendss post-processes a scenario' do
-      expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'opendss'))).to be false
-      system("cp -R #{File.join('spec', 'spec_files', 'opendss')} #{File.join(test_directory, 'run', 'two_building_scenario', 'opendss')}")
-      system("#{call_cli} process --opendss --scenario #{test_scenario} --feature #{test_feature}")
-      expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', '2', 'feature_reports', 'default_feature_report_opendss.csv'))).to be true
-      expect(File.exist?(File.join(test_directory, 'run', 'two_building_scenario', 'process_status.json'))).to be true
+      expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', '2', 'feature_reports', 'default_feature_report_opendss.csv'))).to be false
+      system("#{call_cli} process --opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
+      expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', '2', 'feature_reports', 'default_feature_report_opendss.csv'))).to be true
+      expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'process_status.json'))).to be true
     end
 
     it 'creates scenario visualization for default post processor' do

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -171,12 +171,12 @@ RSpec.describe URBANopt::CLI do
 
   context 'Run and work with a small simulation' do
     before :all do
-      # delete_directory_or_file(test_directory)
-      # delete_directory_or_file(test_directory_res)
-      # delete_directory_or_file(test_directory_elec)
-      # system("#{call_cli} create --project-folder #{test_directory}")
-      # system("#{call_cli} create --project-folder #{test_directory_res} --combined")
-      # system("#{call_cli} create --project-folder #{test_directory_elec} --electric")
+      delete_directory_or_file(test_directory)
+      delete_directory_or_file(test_directory_res)
+      delete_directory_or_file(test_directory_elec)
+      system("#{call_cli} create --project-folder #{test_directory}")
+      system("#{call_cli} create --project-folder #{test_directory_res} --combined")
+      system("#{call_cli} create --project-folder #{test_directory_elec} --electric")
     end
 
     it 'runs a 2 building scenario using default geometry method' do

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'creates an example project directory with electrical network properties' do
-      system("#{call_cli} create --project-folder #{test_directory} --electric")
+      system("#{call_cli} create --project-folder #{test_directory_elec} --electric")
       expect(File.exist?(test_feature_elec)).to be true
     end
 

--- a/uo_cli.gemspec
+++ b/uo_cli.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'optimist', '~> 3'
   spec.add_runtime_dependency 'pycall', '1.3.1'
   spec.add_runtime_dependency 'urbanopt-geojson', '~> 0.5.1'
-  spec.add_runtime_dependency 'urbanopt-reopt', '~> 0.5.0'
+  spec.add_runtime_dependency 'urbanopt-reopt', '~> 0.5.4'
   spec.add_runtime_dependency 'urbanopt-scenario', '~> 0.5.1'
   spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.3.6'
 

--- a/uo_cli.gemspec
+++ b/uo_cli.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pycall', '1.3.1'
   spec.add_runtime_dependency 'urbanopt-geojson', '~> 0.5.1'
   spec.add_runtime_dependency 'urbanopt-reopt', '~> 0.5.0'
-  # spec.add_runtime_dependency 'urbanopt-scenario', '~> 0.5.0'
-  # spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.3.4'
+  spec.add_runtime_dependency 'urbanopt-scenario', '~> 0.5.1'
+  spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.3.6'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
### Resolves #192, Resolves #174, completes #193 

### Pull Request Description

Uses an installation of [ditto-reader](https://pypi.org/project/urbanopt-ditto-reader/) (which includes the cli for that repo) to make the `uo opendss` command work as expected. I'll repeat for the folks in the back: **ditto reader must be installed beforehand!** During testing, you must install from the `cli` branch of ditto-reader. If you install ditto-reader into a virtualenv (good practice), ensure that virtualenv is activated when you call `uo opendss`.

Also includes rspec tests, which for dev work should be excluded (change the test from `it 'does a thing' do...` to `xit 'does a thing' do...` for the test to run the electrical_network and to run opendss (lines 224 & 268, respectively). The only reason to exclude these tests is because it takes a long time to run a scenario of 13 large buildings. Less dev hairpulling if you skip these two tests.

### Checklist

I expect the `opendss` test to fail, because Jenkins does not have Python & ditto-reader installed, which that test depends on.

- [x] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
