### PR TITLE
bugfix for setting opendss timesteps

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -709,10 +709,10 @@ module URBANopt
           ditto_cli_addition += " --timestep #{@opthash.subopts[:timestep]}"
         end
         if @opthash.subopts[:start_time]
-          ditto_cli_addition += " --start_time #{@opthash.subopts[:start_time]}"
+          ditto_cli_addition += " --start_time '#{@opthash.subopts[:start_time]}'"
         end
         if @opthash.subopts[:end_time]
-          ditto_cli_addition += " --end_time #{@opthash.subopts[:end_time]}"
+          ditto_cli_addition += " --end_time '#{@opthash.subopts[:end_time]}'"
         end
       else
         abort("\nCommand must include ScenarioFile & FeatureFile, or a config file that specifies both. Please try again")

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -272,9 +272,7 @@ RSpec.describe URBANopt::CLI do
 
     it 'successfully gets results from the opendss cli' do
       system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-      # system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-time '2017/01/15 01:00:00' --end-time '2017/01/22 01:00:00'")
-      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-
+      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-time '2017/01/15 01:00:00' --end-time '2017/01/22 01:00:00'")
       expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
     end
 


### PR DESCRIPTION
### Pull Request Description
Quick bugfix for opendss timesteps
- Needed an additional set of quotes in the code for the quotes from the user to pass through.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
