### PR TITLE
error handling when no/wrong commands given to cli

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -77,7 +77,11 @@ module URBANopt
         end
         return if ARGV.empty?
         @command = ARGV.shift
-        send("opt_#{@command}") ## dispatch to command handling method
+        begin
+          send("opt_#{@command}") ## dispatch to command handling method
+        rescue NoMethodError
+          abort("Invalid command, please run uo --help for a list of available commands")
+        end
       end
 
       # Define creation commands
@@ -266,10 +270,16 @@ module URBANopt
     # Initialize the CLI class
     @opthash = UrbanOptCLI.new
 
-    # Pull out feature and scenario filenames and paths
-    if @opthash.subopts[:scenario_file]
-      @feature_path, @feature_name = File.split(File.expand_path(@opthash.subopts[:scenario_file]))
+    # Rescue if user only enters 'uo' without a command
+    begin
+      # Pull out feature and scenario filenames and paths
+      if @opthash.subopts[:scenario_file]
+        @feature_path, @feature_name = File.split(File.expand_path(@opthash.subopts[:scenario_file]))
+      end
+    rescue NoMethodError
+      abort("Invalid command, please run uo --help for a list of available commands")
     end
+
     # FIXME: Can this be combined with the above block? This isn't very DRY
     # One solution would be changing scenario_file to feature.
     #   Would that be confusing when creating a ScenarioFile from the FeatureFile?

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe URBANopt::CLI do
         .to output(a_string_including('Create project directory'))
         .to_stdout_from_any_process
     end
+
+    it 'returns graceful error when no command given' do
+      expect { system(call_cli) }
+        .to output(a_string_including('Invalid command'))
+        .to_stderr_from_any_process
+    end
+
+    it 'returns graceful error when invalid command given' do
+      expect { system("#{call_cli} asdf") }
+        .to output(a_string_including('Invalid command'))
+        .to_stderr_from_any_process
+    end
   end
 
   context 'Create project' do


### PR DESCRIPTION
### Resolves #190 

### Pull Request Description
Handle cases where user inputs wrong command, or none at all, after the `uo` entry
### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
