### PR TITLE
error handling for create -s command

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -312,7 +312,16 @@ module URBANopt
     # params\
     # +feature_file_path+:: _string_ Path to a FeatureFile
     def self.create_scenario_csv_file(feature_id)
-      feature_file_json = JSON.parse(File.read(File.expand_path(@opthash.subopts[:scenario_file])), symbolize_names: true)
+      begin
+        feature_file_json = JSON.parse(File.read(File.expand_path(@opthash.subopts[:scenario_file])), symbolize_names: true)
+      # Rescue if user provides path to a dir and not a file
+      rescue Errno::EISDIR => dir_error
+        wrong_path = dir_error.to_s.split(' - ')[-1]
+        abort("\nOops! '#{wrong_path}' is a directory. Please provide path to the geojson feature_file")
+        # Rescue if file isn't json
+      rescue JSON::ParserError => json_error
+        abort("\nOops! You didn't provide a json file. Please provide path to the geojson feature_file")
+      end
       Dir["#{@feature_path}/mappers/*.rb"].each do |mapper_file|
         mapper_name = File.basename(mapper_file, File.extname(mapper_file))
         scenario_file_name = if feature_id == 'SKIP'
@@ -322,20 +331,25 @@ module URBANopt
                              end
         CSV.open(File.join(@feature_path, scenario_file_name), 'wb', write_headers: true,
                                                                      headers: ['Feature Id', 'Feature Name', 'Mapper Class']) do |csv|
-          feature_file_json[:features].each do |feature|
-            if feature_id == 'SKIP'
-              # ensure that feature is a building
-              if feature[:properties][:type] == 'Building'
+          begin
+              feature_file_json[:features].each do |feature|
+              if feature_id == 'SKIP'
+                # ensure that feature is a building
+                if feature[:properties][:type] == 'Building'
+                  csv << [feature[:properties][:id], feature[:properties][:name], "URBANopt::Scenario::#{mapper_name}Mapper"]
+                end
+              elsif feature_id == feature[:properties][:id]
                 csv << [feature[:properties][:id], feature[:properties][:name], "URBANopt::Scenario::#{mapper_name}Mapper"]
-              end
-            elsif feature_id == feature[:properties][:id]
-              csv << [feature[:properties][:id], feature[:properties][:name], "URBANopt::Scenario::#{mapper_name}Mapper"]
-            elsif
-              # If Feature ID specified does not exist in the Feature File raise error
-              unless feature_file_json[:features].any? { |hash| hash[:properties][:id].include?(feature_id.to_s) }
-                abort("\nYou must provide Feature ID from FeatureFile!\n---\n\n")
+              elsif
+                # If Feature ID specified does not exist in the Feature File raise error
+                unless feature_file_json[:features].any? { |hash| hash[:properties][:id].include?(feature_id.to_s) }
+                  abort("\nYou must provide Feature ID from FeatureFile!\n---\n\n")
+                end
               end
             end
+            # Rescue if json isn't a geojson feature_file
+          rescue NoMethodError
+            abort("\nOops! You didn't provde a valid feature_file. Please provide path to the geojson feature_file")
           end
         end
       end

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe URBANopt::CLI do
       end
       expect { system("#{call_cli} create -s #{test_directory}/runner.conf") }
         .to output(a_string_including("didn't provde a valid feature_file."))
+        .to_stderr_from_any_process
     end
 
     it 'returns graceful error when no command given' do

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -70,6 +70,33 @@ RSpec.describe URBANopt::CLI do
         .to output(a_string_including('Create project directory'))
         .to_stdout_from_any_process
     end
+
+    it 'returns graceful error message if dir passed to "create -s" command' do
+      unless Dir.exist?(File.expand_path(test_directory))
+        system("#{call_cli} create --project-folder #{test_directory}")
+      end
+      expect { system("#{call_cli} create -s #{test_directory}") }
+        .to output(a_string_including('is a directory.'))
+        .to_stderr_from_any_process
+    end
+
+    it 'returns graceful error message if non-json file passed to create -s command' do
+      unless Dir.exist?(File.expand_path(test_directory))
+        system("#{call_cli} create --project-folder #{test_directory}")
+      end
+      expect { system("#{call_cli} create -s #{test_directory}/validation_schema.yaml") }
+        .to output(a_string_including("didn't provide a json file."))
+        .to_stderr_from_any_process
+    end
+
+    it 'returns graceful error message if invalid json file passed to create -s command' do
+      unless Dir.exist?(File.expand_path(test_directory))
+        system("#{call_cli} create --project-folder #{test_directory}")
+      end
+      expect { system("#{call_cli} create -s #{test_directory}/runner.conf") }
+        .to output(a_string_including("didn't provde a valid feature_file."))
+        .to_stderr_from_any_process
+    end
   end
 
   context 'Create project' do


### PR DESCRIPTION
### Resolves #191 

### Pull Request Description
Graceful error messages if invalid files passed to `uo create -s` command

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
