### PR TITLE
update hpxml bundle

### DIFF
--- a/example_files/resources/hpxml-measures/Gemfile.lock
+++ b/example_files/resources/hpxml-measures/Gemfile.lock
@@ -1,54 +1,39 @@
-GIT
-  remote: http://github.com/shorowit/schematron.git
-  revision: 2e26890fa1fc918198270f94abc7caf659d18bb2
-  branch: return_context_path
-  specs:
-    schematron-nokogiri (0.0.2)
-      nokogiri (~> 1.6)
-
 GEM
   remote: http://rubygems.org/
   specs:
     ansi (1.5.0)
-    ast (2.4.1)
+    ast (2.4.2)
     builder (3.2.4)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_minitest (1.0.0)
       ci_reporter (~> 2.0)
       minitest (~> 5.0)
-    codecov (0.2.0)
-      colorize
-      json
-      simplecov
-    colorize (0.8.1)
-    docile (1.3.2)
-    json (2.3.1)
-    mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    codecov (0.5.1)
+      simplecov (>= 0.15, < 0.22)
+    docile (1.3.5)
+    minitest (5.14.4)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
-    minitest-reporters (1.4.2)
+    minitest-reporters (1.4.3)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.10-x64-mingw32)
-      mini_portile2 (~> 2.4.0)
-    oga (3.2)
+    oga (3.3)
       ast
       ruby-ll (~> 2.1)
-    rake (13.0.1)
+    rake (13.0.3)
     ruby-ll (2.1.2)
       ansi
       ast
-    ruby-progressbar (1.10.1)
-    simplecov (0.18.5)
+    ruby-progressbar (1.11.0)
+    simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
 
 PLATFORMS
   ruby
@@ -60,11 +45,9 @@ DEPENDENCIES
   minitest (~> 5.9)
   minitest-ci
   minitest-reporters
-  nokogiri (~> 1.10)
   oga
   rake
-  schematron-nokogiri!
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.2.7


### PR DESCRIPTION
### Resolves dependabot alert

### Pull Request Description
Old version of nokogiri had a security vulnerability. Turns out we don't use nokogiri, and doing a `bundle update` in the hpxml dir cleaned up that dependency.
### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
