### PR TITLE
default PV assumtions so no system is automatically sized

### DIFF
--- a/example_files/reopt/base_assumptions.json
+++ b/example_files/reopt/base_assumptions.json
@@ -50,7 +50,6 @@
         "pv_name": "Roof - South Face",
         "location":"roof",
         "existing_kw": 0,
-        "existing_kw": 0,
         "min_kw": 0,
         "max_kw": 1000000000.0,
         "installed_cost_us_dollars_per_kw": 1600,

--- a/example_files/reopt/base_assumptions.json
+++ b/example_files/reopt/base_assumptions.json
@@ -21,7 +21,8 @@
         "add_blended_rates_to_urdb_rate": false,
         "net_metering_limit_kw": 0,
         "interconnection_limit_kw": 100000000.0,
-       "urdb_label": "5e162e2a5457a3d50873e3af"
+        "blended_monthly_demand_charges_us_dollars_per_kw": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10], 
+        "blended_monthly_rates_us_dollars_per_kwh": [0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13] 
       },
       "Wind": {
         "min_kw": 0,

--- a/example_files/reopt/multiPV_assumptions.json
+++ b/example_files/reopt/multiPV_assumptions.json
@@ -50,7 +50,7 @@
         "pv_name": "Roof - South Face",
         "location":"roof",
         "existing_kw": 0,
-        "min_kw": 1.6,
+        "min_kw": 0,
         "max_kw": 1000000000.0,
         "installed_cost_us_dollars_per_kw": 1600,
         "om_cost_us_dollars_per_kw": 16,
@@ -85,7 +85,7 @@
       {
         "pv_name": "Groundmount",
         "location":"ground",
-        "existing_kw": 5,
+        "existing_kw": 0,
         "min_kw": 0,
         "max_kw": 1000000000.0,
         "installed_cost_us_dollars_per_kw": 2200,

--- a/example_files/reopt/multiPV_assumptions.json
+++ b/example_files/reopt/multiPV_assumptions.json
@@ -21,7 +21,8 @@
         "add_blended_rates_to_urdb_rate": false,
         "net_metering_limit_kw": 0,
         "interconnection_limit_kw": 100000000.0,
-       "urdb_label": "5e162e2a5457a3d50873e3af"
+        "blended_monthly_demand_charges_us_dollars_per_kw": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10], 
+        "blended_monthly_rates_us_dollars_per_kwh": [0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13] 
       },
       "Wind": {
         "min_kw": 0,


### PR DESCRIPTION
### Description
Updates default PV assumptions to avoid future confusion
Uses average monthly energy and demand charges instead of specific rates

### Checklist (Delete lines that don't apply)
- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
