### PR TITLE
Fix create bar worklfow when detailed model is present

### DIFF
--- a/example_files/mappers/CreateBar.rb
+++ b/example_files/mappers/CreateBar.rb
@@ -316,6 +316,15 @@ module URBANopt
             osw[:file_paths] << File.join(File.dirname(__FILE__), '../osm_building/')
             osw[:seed_file] = detailed_model_filename
 
+            # skip create_bar measure with detailed models:
+            OpenStudio::Extension.set_measure_argument(osw, 'create_bar_from_building_type_ratios', '__SKIP__', true)
+
+            # skip create typical building measure with detailed models:
+            OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', '__SKIP__', true)
+
+            # skip PMV measure with detailed models:
+            OpenStudio::Extension.set_measure_argument(osw, 'PredictedMeanVote', '__SKIP__', true)
+
             # skip PMV measure with detailed models:
             OpenStudio::Extension.set_measure_argument(osw, 'PredictedMeanVote', '__SKIP__', true)
 

--- a/example_files/mappers/CreateBar.rb
+++ b/example_files/mappers/CreateBar.rb
@@ -322,8 +322,6 @@ module URBANopt
             # skip create typical building measure with detailed models:
             OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', '__SKIP__', true)
 
-            # skip PMV measure with detailed models:
-            OpenStudio::Extension.set_measure_argument(osw, 'PredictedMeanVote', '__SKIP__', true)
 
             # skip PMV measure with detailed models:
             OpenStudio::Extension.set_measure_argument(osw, 'PredictedMeanVote', '__SKIP__', true)


### PR DESCRIPTION
### Resolves #275 

### Pull Request Description

When detailed model is present the create bar mapper skips create bar, create typical building measures

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
