### PR TITLE
feat: add renewable min/max pct to reopt call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-scenario-gem')
 #  gem 'urbanopt-scenario', path: '../urbanopt-scenario-gem'
 # elsif allow_local
-# gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
+gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
 # end
 
 # if allow_local && File.exist?('../urbanopt-geojson-gem')

--- a/example_files/reopt/base_assumptions.json
+++ b/example_files/reopt/base_assumptions.json
@@ -1,6 +1,8 @@
 {
   "Scenario": {
     "Site": {
+      "renewable_electricity_min_pct": 0.0,
+      "renewable_electricity_max_pct": 100.0,
       "Financial": {
         "om_cost_escalation_pct": 0.025,
         "escalation_pct": 0.023,
@@ -21,7 +23,7 @@
         "add_blended_rates_to_urdb_rate": false,
         "net_metering_limit_kw": 0,
         "interconnection_limit_kw": 100000000.0,
-        "blended_monthly_demand_charges_us_dollars_per_kw": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10], 
+        "blended_monthly_demand_charges_us_dollars_per_kw": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
         "blended_monthly_rates_us_dollars_per_kwh": [0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13]
      },
       "Wind": {
@@ -143,4 +145,3 @@
     "time_steps_per_hour": 1
   }
 }
-

--- a/example_files/reopt/base_assumptions.json
+++ b/example_files/reopt/base_assumptions.json
@@ -2,8 +2,8 @@
   "Scenario": {
     "off_grid_flag": false,
     "Site": {
-      "renewable_electricity_min_pct": 0.0,
-      "renewable_electricity_max_pct": 100.0,
+      "renewable_electricity_min_pct": 0,
+      "renewable_electricity_max_pct": 1,
       "Financial": {
         "om_cost_escalation_pct": 0.025,
         "escalation_pct": 0.023,

--- a/example_files/reopt/multiPV_assumptions.json
+++ b/example_files/reopt/multiPV_assumptions.json
@@ -1,6 +1,8 @@
 {
   "Scenario": {
     "Site": {
+      "renewable_electricity_min_pct": 0.0,
+      "renewable_electricity_max_pct": 100.0,
       "Financial": {
         "om_cost_escalation_pct": 0.025,
         "escalation_pct": 0.023,
@@ -21,8 +23,8 @@
         "add_blended_rates_to_urdb_rate": false,
         "net_metering_limit_kw": 0,
         "interconnection_limit_kw": 100000000.0,
-        "blended_monthly_demand_charges_us_dollars_per_kw": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10], 
-        "blended_monthly_rates_us_dollars_per_kwh": [0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13] 
+        "blended_monthly_demand_charges_us_dollars_per_kw": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+        "blended_monthly_rates_us_dollars_per_kwh": [0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13]
       },
       "Wind": {
         "min_kw": 0,
@@ -179,4 +181,3 @@
     "time_steps_per_hour": 1
   }
 }
-

--- a/example_files/reopt/multiPV_assumptions.json
+++ b/example_files/reopt/multiPV_assumptions.json
@@ -2,8 +2,8 @@
   "Scenario": {
     "off_grid_flag": false,
     "Site": {
-      "renewable_electricity_min_pct": 0.0,
-      "renewable_electricity_max_pct": 100.0,
+      "renewable_electricity_min_pct": 0,
+      "renewable_electricity_max_pct": 1,
       "Financial": {
         "om_cost_escalation_pct": 0.025,
         "escalation_pct": 0.023,


### PR DESCRIPTION
### Resolves #293 

### Pull Request Description

Enable ability to tell reopt a min/max precent of renewables desired for the scenario, so it will return the optimal amount.
This populates existing fields in the reopt output. No new fields are created.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
