### PR TITLE
Opendss time fix

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -192,25 +192,25 @@ module URBANopt
           "Optional, defaults to analog of simulation timestep set in the FeatureFile\n" \
           "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --timestep 15", type: Integer, short: :t
 
-          opt :start_date, "\nBeginning date for OpenDSS analysis\n" \
+          opt :start_date, "\nBeginning date for OpenDSS analysis specified in YYYY\\MM\\DD format. \n" \
           "Optional, defaults to beginning of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-date '2017/01/15'" \
-          "Ensure you have quotes around the date", type: String
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-date 2017/01/15" \
+          "Ensure you have quotes around the date", type: String, short: :a
 
-          opt :start_time, "\nBeginning time for OpenDSS analysis\n" \
-          "Optional, defaults to beginning of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time '01:00:00'\n" \
-          "Ensure you have quotes around the time.", type: String
+          opt :start_time, "\nBeginning time for OpenDSS analysis specified in hh:mm:ss format. \n" \
+          "Optional, defaults to 00:00:00 of start_date if specified, otherwise beginning of simulation time\n" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time 01:00:00\n" \
+          "Ensure you have quotes around the time.", type: String, short: :b
 
-          opt :end_date, "\End date for OpenDSS analysis\n" \
+          opt :end_date, "\nEnd date for OpenDSS analysis specified in YYYY\\MM\\DD format.\n" \
           "Optional, defaults to end of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-date '2017/01/16'" \
-          "Ensure you have quotes around the date", type: String
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-date 2017/01/16" \
+          "Ensure you have quotes around the date", type: String, short: :z
 
-          opt :end_time, "\End time for OpenDSS analysis\n" \
-          "Optional, defaults to end of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time '01:00:00'\n" \
-          "Ensure you have quotes around the time.", type: String
+          opt :end_time, "\nEnd time for OpenDSS analysis specified in hh:mm:ss format. \n" \
+          "Optional, defaults to 23:00:00 of end_date if specified, otherwise end of simulation time is used. \n" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time 01:00:00\n" \
+          "Ensure you have quotes around the time.", type: String, short: :y
 
           opt :upgrade, "\nUpgrade undersized transformers\n" \
           "Optional, defaults to false if not provided\n" \

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -194,23 +194,19 @@ module URBANopt
 
           opt :start_date, "\nBeginning date for OpenDSS analysis specified in YYYY\\MM\\DD format. \n" \
           "Optional, defaults to beginning of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-date 2017/01/15" \
-          "Ensure you have quotes around the date", type: String, short: :a
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-date 2017/01/15", type: String, short: :a
 
           opt :start_time, "\nBeginning time for OpenDSS analysis specified in hh:mm:ss format. \n" \
           "Optional, defaults to 00:00:00 of start_date if specified, otherwise beginning of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time 01:00:00\n" \
-          "Ensure you have quotes around the time.", type: String, short: :b
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time 01:00:00\n", type: String, short: :b
 
           opt :end_date, "\nEnd date for OpenDSS analysis specified in YYYY\\MM\\DD format.\n" \
           "Optional, defaults to end of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-date 2017/01/16" \
-          "Ensure you have quotes around the date", type: String, short: :z
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-date 2017/01/16", type: String, short: :z
 
           opt :end_time, "\nEnd time for OpenDSS analysis specified in hh:mm:ss format. \n" \
           "Optional, defaults to 23:00:00 of end_date if specified, otherwise end of simulation time is used. \n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time 01:00:00\n" \
-          "Ensure you have quotes around the time.", type: String, short: :y
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time 01:00:00\n", type: String, short: :y
 
           opt :upgrade, "\nUpgrade undersized transformers\n" \
           "Optional, defaults to false if not provided\n" \

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -194,22 +194,22 @@ module URBANopt
 
           opt :start_date, "\nBeginning date for OpenDSS analysis\n" \
           "Optional, defaults to beginning of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-date '2017/01/15'" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start_date '2017/01/15'" \
           "Ensure you have double quotes around the date", type: String
 
           opt :start_time, "\nBeginning time for OpenDSS analysis\n" \
           "Optional, defaults to beginning of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time '01:00:00'\n" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start_time '01:00:00'\n" \
           "Ensure you have double quotes around the time.", type: String
 
           opt :end_date, "\End date for OpenDSS analysis\n" \
           "Optional, defaults to end of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-date '2017/01/16'" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end_date '2017/01/16'" \
           "Ensure you have double quotes around the date", type: String
 
           opt :end_time, "\End time for OpenDSS analysis\n" \
           "Optional, defaults to end of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time '01:00:00'\n" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end_time '01:00:00'\n" \
           "Ensure you have double quotes around the time.", type: String
 
           opt :upgrade, "\nUpgrade undersized transformers\n" \

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -192,15 +192,25 @@ module URBANopt
           "Optional, defaults to analog of simulation timestep set in the FeatureFile\n" \
           "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --timestep 15", type: Integer, short: :t
 
-          opt :start_time, "\nBeginning of the period for OpenDSS analysis\n" \
-          "Optional, defaults to beginning of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time '2017/01/15 01:00:00'\n" \
-          "Ensure you have quotes around the timestamp, to allow for the space between date & time.", type: String
+          opt :start_date, "\nBeginning date for OpenDSS analysis\n" \
+          "Optional, defaults to beginning of simulation date\n" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-date '2017/01/15'" \
+          "Ensure you have double quotes around the date", type: String
 
-          opt :end_time, "\nEnd of the period for OpenDSS analysis\n" \
+          opt :start_time, "\nBeginning time for OpenDSS analysis\n" \
+          "Optional, defaults to beginning of simulation time\n" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time '01:00:00'\n" \
+          "Ensure you have double quotes around the time.", type: String
+
+          opt :end_date, "\End date for OpenDSS analysis\n" \
+          "Optional, defaults to end of simulation date\n" \
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-date '2017/01/16'" \
+          "Ensure you have double quotes around the date", type: String
+
+          opt :end_time, "\End time for OpenDSS analysis\n" \
           "Optional, defaults to end of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time '2017/01/16 01:00:00'\n" \
-          "Ensure you have quotes around the timestamp, to allow for the space between date & time.", type: String
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time '01:00:00'\n" \
+          "Ensure you have double quotes around the time.", type: String
 
           opt :upgrade, "\nUpgrade undersized transformers\n" \
           "Optional, defaults to false if not provided\n" \
@@ -878,11 +888,17 @@ module URBANopt
         if @opthash.subopts[:timestep]
           ditto_cli_addition += " --timestep #{@opthash.subopts[:timestep]}"
         end
+        if @opthash.subopts[:start_date]
+          ditto_cli_addition += " --start_date #{@opthash.subopts[:start_date]}"
+        end
         if @opthash.subopts[:start_time]
-          ditto_cli_addition += " --start_time '#{@opthash.subopts[:start_time]}'"
+          ditto_cli_addition += " --start_time #{@opthash.subopts[:start_time]}"
+        end
+        if @opthash.subopts[:end_date]
+          ditto_cli_addition += " --end_date #{@opthash.subopts[:end_date]}"
         end
         if @opthash.subopts[:end_time]
-          ditto_cli_addition += " --end_time '#{@opthash.subopts[:end_time]}'"
+          ditto_cli_addition += " --end_time #{@opthash.subopts[:end_time]}"
         end
         if @opthash.subopts[:upgrade]
           ditto_cli_addition += " --upgrade"

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -194,23 +194,23 @@ module URBANopt
 
           opt :start_date, "\nBeginning date for OpenDSS analysis\n" \
           "Optional, defaults to beginning of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start_date '2017/01/15'" \
-          "Ensure you have double quotes around the date", type: String
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-date '2017/01/15'" \
+          "Ensure you have quotes around the date", type: String
 
           opt :start_time, "\nBeginning time for OpenDSS analysis\n" \
           "Optional, defaults to beginning of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start_time '01:00:00'\n" \
-          "Ensure you have double quotes around the time.", type: String
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --start-time '01:00:00'\n" \
+          "Ensure you have quotes around the time.", type: String
 
           opt :end_date, "\End date for OpenDSS analysis\n" \
           "Optional, defaults to end of simulation date\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end_date '2017/01/16'" \
-          "Ensure you have double quotes around the date", type: String
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-date '2017/01/16'" \
+          "Ensure you have quotes around the date", type: String
 
           opt :end_time, "\End time for OpenDSS analysis\n" \
           "Optional, defaults to end of simulation time\n" \
-          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end_time '01:00:00'\n" \
-          "Ensure you have double quotes around the time.", type: String
+          "Example: uo opendss --scenario baseline_scenario.csv --feature example_project.json --end-time '01:00:00'\n" \
+          "Ensure you have quotes around the time.", type: String
 
           opt :upgrade, "\nUpgrade undersized transformers\n" \
           "Optional, defaults to false if not provided\n" \

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe URBANopt::CLI do
     before :all do
       delete_directory_or_file(test_directory)
       delete_directory_or_file(test_directory_pv)
-      system("#{call_cli} create --project-folder ##{test_directory}")
+      system("#{call_cli} create --project-folder #{test_directory}")
       system("#{call_cli} create --project-folder #{test_directory_pv}")
     end
 

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -343,9 +343,9 @@ RSpec.describe URBANopt::CLI do
 
     it 'successfully gets results from the opendss cli' do
       system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end-time '00:00:00'")
+      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start_date '2017/01/15' --start_time '01:00:00' --end_date '2017/01/16' --end_time '00:00:00'")
       expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
-      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end-time '00:00:00' --upgrade") }
+      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start_date '2017/01/15' --start_time '01:00:00' --end_date '2017/01/16' --end_time '00:00:00' --upgrade") }
         .to output(a_string_including('Upgrading undersized transformers:'))
         .to_stdout_from_any_process
     end

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe URBANopt::CLI do
     before :all do
       delete_directory_or_file(test_directory)
       delete_directory_or_file(test_directory_pv)
-      system("#{call_cli} create --project-folder #{test_directory}")
+      system("#{call_cli} create --project-folder ##{test_directory}")
       system("#{call_cli} create --project-folder #{test_directory_pv}")
     end
 
@@ -343,9 +343,9 @@ RSpec.describe URBANopt::CLI do
 
     it 'successfully gets results from the opendss cli' do
       system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start_date '2017/01/15' --start_time '01:00:00' --end_date '2017/01/16' --end_time '00:00:00'")
+      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end-time '00:00:00'")
       expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
-      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start_date '2017/01/15' --start_time '01:00:00' --end_date '2017/01/16' --end_time '00:00:00' --upgrade") }
+      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end_time '00:00:00' --upgrade") }
         .to output(a_string_including('Upgrading undersized transformers:'))
         .to_stdout_from_any_process
     end

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -343,9 +343,9 @@ RSpec.describe URBANopt::CLI do
 
     it 'successfully gets results from the opendss cli' do
       system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end-time '00:00:00'")
+      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date 2017/01/15 --start-time 01:00:00 --end-date 2017/01/16 --end-time 00:00:00")
       expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
-      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end_time '00:00:00' --upgrade") }
+      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date 2017/01/15 --start-time 01:00:00 --end-date 2017/01/16 --end_time 00:00:00 --upgrade") }
         .to output(a_string_including('Upgrading undersized transformers:'))
         .to_stdout_from_any_process
     end

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -343,9 +343,9 @@ RSpec.describe URBANopt::CLI do
 
     it 'successfully gets results from the opendss cli' do
       system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
-      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-time '2017/01/15 01:00:00' --end-time '2017/01/16 00:00:00'")
+      system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end-time '00:00:00'")
       expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
-      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-time '2017/01/15 01:00:00' --end-time '2017/01/16 00:00:00' --upgrade") }
+      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date '2017/01/15' --start-time '01:00:00' --end-date '2017/01/16' --end-time '00:00:00' --upgrade") }
         .to output(a_string_including('Upgrading undersized transformers:'))
         .to_stdout_from_any_process
     end


### PR DESCRIPTION
### Resolves #286 

### Pull Request Description

The OpenDSS run cli command has additional arguments to indicate the start and end date of simulation. In the current implementation a user can indicate the start/end date as well as time. Adding the time argument separated by a space from the date was throwing an error in windows for an extra argument.
The start/end date and time are not added as separate arguments. There are passed on to the ditto cli, where they are combined before being added to the config file to run the simulation.

To test: 

pip install -e {local ditto reader repo on opendss_time_fix branch}
bundle exec uo opendss -s {path to scenario} -f {path to geojson} --start-date "2017/01/01" --start-time "01:00:00"--end-time "2017/01/02" --end-time "01:00:00"

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
