### PR TITLE
test bug: change underscore to dash to fix opendss test

### DIFF
--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe URBANopt::CLI do
       system("#{call_cli} process --default --scenario #{test_scenario_elec} --feature #{test_feature_elec}")
       system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date 2017/01/15 --start-time 01:00:00 --end-date 2017/01/16 --end-time 00:00:00")
       expect(File.exist?(File.join(test_directory_elec, 'run', 'electrical_scenario', 'opendss', 'profiles', 'load_1.csv'))).to be true
-      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date 2017/01/15 --start-time 01:00:00 --end-date 2017/01/16 --end_time 00:00:00 --upgrade") }
+      expect { system("#{call_cli} opendss --scenario #{test_scenario_elec} --feature #{test_feature_elec} --start-date 2017/01/15 --start-time 01:00:00 --end-date 2017/01/16 --end-time 00:00:00 --upgrade") }
         .to output(a_string_including('Upgrading undersized transformers:'))
         .to_stdout_from_any_process
     end


### PR DESCRIPTION
### Pull Request Description

One opendss test had a tiny bug where the call to the opendss cli wasn't correct. This fixes it.

As long as the develop branch of ditto-reader is installed, this works (0.3.13 doesn't include this, so if the CI is using the released version it will still the test).

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [x] This branch is up-to-date with develop
