### PR TITLE
Add measure argument to use model occupancy for ev measure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../openstudio-common-measures-gem')
 #   gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 # elsif allow_local
-   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'ev_enhacement'
+   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'ev_enhancement'
 # end
 
 # if allow_local && File.exist?('../openstudio-model-articulation-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../openstudio-common-measures-gem')
 #   gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 # elsif allow_local
-   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'ev_enhancement'
+   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'develop'
 # end
 
 # if allow_local && File.exist?('../openstudio-model-articulation-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,12 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
 # end
 
+# TODO : Uncomment to revert changes to gem paths
+
 # if allow_local && File.exist?('../urbanopt-geojson-gem')
 #   gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
 # elsif allow_local
-gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'develop'
+gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'ev_charging'
 # end
 
 # if allow_local && File.exist?('../urbanopt-reopt-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,12 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 #   gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'develop'
 # end
 
+# TODO : Uncomment to revert changes once gem is released
+
 # if allow_local && File.exist?('../openstudio-common-measures-gem')
 #   gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 # elsif allow_local
-#   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'develop'
+   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'ev_enhacement'
 # end
 
 # if allow_local && File.exist?('../openstudio-model-articulation-gem')
@@ -39,12 +41,12 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
 # end
 
-# TODO : Uncomment to revert changes to gem paths
+# TODO : Uncomment to revert changes once gem is released
 
 # if allow_local && File.exist?('../urbanopt-geojson-gem')
 #   gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
 # elsif allow_local
-gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'ev_charging'
+gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'develop'
 # end
 
 # if allow_local && File.exist?('../urbanopt-reopt-gem')

--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -26,13 +26,14 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # end
 #
 
-if allow_local && File.exist?('../openstudio-common-measures-gem')
-  gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
-elsif allow_local
-  gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'develop'
-else
-  gem 'openstudio-common-measures', '~> 0.5.0'
-end
+# TODO : Uncomment to revert changes to gem paths
+#if allow_local && File.exist?('../openstudio-common-measures-gem')
+#  gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
+#elsif allow_local
+  gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'ev_enhancement'
+#else
+#  gem 'openstudio-common-measures', '~> 0.5.0'
+#end
 
 if allow_local && File.exist?('../openstudio-model-articulation-gem')
   gem 'openstudio-model-articulation', path: '../openstudio-model-articulation-gem'
@@ -66,13 +67,14 @@ else
   gem 'openstudio-calibration', '~> 0.5.0'
 end
 
-if allow_local && File.exists?('../urbanopt-geojson-gem')
-  gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
-elsif allow_local
-  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'develop'
-else
-  gem 'urbanopt-geojson', '~> 0.7.0'
-end
+# TODO : Uncomment to revert changes to geojson gem paths
+#if allow_local && File.exists?('../urbanopt-geojson-gem')
+#  gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
+#elsif allow_local
+  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'ev_charging'
+#else
+#  gem 'urbanopt-geojson', '~> 0.7.0'
+#end
 
 # NEVER put SCENARIO-GEM in this file...it will make all simulations fail due to the sqlite dependency
 # gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'

--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -30,7 +30,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 #if allow_local && File.exist?('../openstudio-common-measures-gem')
 #  gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 #elsif allow_local
-  gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'ev_enhancement'
+  gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'develop'
 #else
 #  gem 'openstudio-common-measures', '~> 0.5.0'
 #end

--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -67,11 +67,11 @@ else
   gem 'openstudio-calibration', '~> 0.5.0'
 end
 
-# TODO : Uncomment to revert changes to geojson gem paths
+# TODO : Uncomment and revert once gem is released
 #if allow_local && File.exists?('../urbanopt-geojson-gem')
 #  gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
 #elsif allow_local
-  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'ev_charging'
+  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'develop'
 #else
 #  gem 'urbanopt-geojson', '~> 0.7.0'
 #end

--- a/example_files/example_project.json
+++ b/example_files/example_project.json
@@ -122,6 +122,7 @@
         "ev_charging": true,
         "ev_charging_behavior": "Business as Usual",
         "ev_percent": 100,
+        "ev_use_model_occupancy": true,
         "ev_curtailment_frac": 0.5
       },
       "geometry": {

--- a/example_files/mappers/EvCharging.rb
+++ b/example_files/mappers/EvCharging.rb
@@ -124,7 +124,7 @@ module URBANopt
           
           begin
             ev_use_model_occupancy = feature.ev_use_model_occupancy
-            if !ev_use_model_occupancy.nil? && !ev_use_model_occupancy.empty?
+            if !ev_use_model_occupancy.nil?
               OpenStudio::Extension.set_measure_argument(osw, 'add_ev_load', 'ev_use_model_occupancy', ev_use_model_occupancy)
             end
           rescue

--- a/example_files/mappers/EvCharging.rb
+++ b/example_files/mappers/EvCharging.rb
@@ -121,6 +121,15 @@ module URBANopt
           rescue
           end
 
+          
+          begin
+            ev_use_model_occupancy = feature.ev_use_model_occupancy
+            if !ev_use_model_occupancy.nil? && !ev_use_model_occupancy.empty?
+              OpenStudio::Extension.set_measure_argument(osw, 'add_ev_load', 'ev_use_model_occupancy', ev_use_model_occupancy)
+            end
+          rescue
+          end
+
           #Add EMS Control to EV charging only if ev_charging is true
           begin
             ev_curtailment_frac = feature.ev_curtailment_frac

--- a/example_files/mappers/base_workflow.osw
+++ b/example_files/mappers/base_workflow.osw
@@ -67,7 +67,7 @@
         "chg_station_type": "Typical Public",
         "delay_type": "Min Delay",
         "charge_behavior": "Business as Usual",
-        "ev_use_model_occupancy": true,
+        "ev_use_model_occupancy": false,
         "ev_percent": 100
       }
     },{

--- a/example_files/mappers/base_workflow.osw
+++ b/example_files/mappers/base_workflow.osw
@@ -67,6 +67,7 @@
         "chg_station_type": "Typical Public",
         "delay_type": "Min Delay",
         "charge_behavior": "Business as Usual",
+        "ev_use_model_occupancy": true,
         "ev_percent": 100
       }
     },{


### PR DESCRIPTION
### Resolves #303 

### Pull Request Description

Adds argument to add_ev measure to use openstudio  model occupancy to determine number of EVs associated with a building feature

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
