### PR TITLE
Add gmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,7 @@
 .rspec_status
 
 # rspec test folder
-spec/test_directory
-spec/test_directory_res
-spec/test_directory_elec
-spec/test_directory_*
+spec/test_directory*
 
 Gemfile.lock
 .rubocop*


### PR DESCRIPTION
### Resolves #359 

### Pull Request Description

- Add gmt to list of Python dependencies that get installed when a user calls `uo install_python`
- Hook up existing gmt commands to work with new path to gmt location
- Make tiny change to simplify gitignore file

### Checklist (Delete lines that don't apply)

- [ ] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
