### PR TITLE
Fix for non-integer feature IDs and Residential workflow

### DIFF
--- a/example_files/mappers/Baseline.rb
+++ b/example_files/mappers/Baseline.rb
@@ -810,7 +810,7 @@ module URBANopt
               feature_ids << feature.id
             end
 
-            args[:feature_id] = feature_id
+            args[:feature_id] = feature_ids.index(feature_id)
             args[:schedules_random_seed] = feature_ids.index(feature_id)
             args[:schedules_type] = 'stochastic' # smooth or stochastic
             args[:schedules_variation] = 'unit' # building or unit


### PR DESCRIPTION
Fixes #362 
Use feature index in geojson file instead of its ID for argument into BuildResidentialModel measure. The argument's type is set to integer and will error out when given a UUID