### PR TITLE
Num parallel bug

### DIFF
--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -821,13 +821,13 @@ module URBANopt
       if ENV['UO_NUM_PARALLEL'] || @opthash.subopts[:num_parallel]
         runner_file_path = File.join(@root_dir, 'runner.conf')
         runner_conf_hash = JSON.parse(File.read(runner_file_path))
-        if ENV['UO_NUM_PARALLEL']
-          runner_conf_hash['num_parallel'] = ENV['UO_NUM_PARALLEL'].to_i
+        if @opthash.subopts[:num_parallel]
+          runner_conf_hash['num_parallel'] = @opthash.subopts[:num_parallel]
           File.open(runner_file_path, 'w+') do |f|
             f << runner_conf_hash.to_json
           end
-        elsif @opthash.subopts[:num_parallel]
-          runner_conf_hash['num_parallel'] = @opthash.subopts[:num_parallel].to_i
+        elsif ENV['UO_NUM_PARALLEL']
+          runner_conf_hash['num_parallel'] = ENV['UO_NUM_PARALLEL'].to_i
           File.open(runner_file_path, 'w+') do |f|
             f << runner_conf_hash.to_json
           end

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -173,7 +173,7 @@ module URBANopt
 
           opt :num_parallel, "\nOPTIONAL: Run URBANopt simulations in parallel using <num_parallel> cores\n" \
           "Adjusts value of 'num_parallel' in the 'runner.conf' file\n" \
-          "Example: uo run --num-parallel 2\n", short: :n
+          "Example: uo run --num-parallel 2\n", type: Integer, short: :n
         end
       end
 


### PR DESCRIPTION
### Resolves #368 

### Pull Request Description

- When `num-parallel` flag is used with the `run` command, enforce that the value of num-parallel is an integer
- Switch priority so the `num-parallel` flag can be set to override the env var on a particular run

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
