### PR TITLE
allow geojson file type as well as json for feature files

### DIFF
--- a/example_files/python_deps/dependencies.json
+++ b/example_files/python_deps/dependencies.json
@@ -1,5 +1,5 @@
-[ 
-  { "name": "urbanopt-ditto-reader", "version": "0.5.1"}, 
+[
+  { "name": "urbanopt-ditto-reader", "version": "0.5.1"},
   { "name": "NREL-disco", "version": "0.4.1"},
-  { "name": "geojson-modelica-translator", "version": "0.4.0"}
+  { "name": "geojson-modelica-translator", "version": "0.5.0"}
 ]

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -1578,7 +1578,7 @@ module URBANopt
       end
 
       if @opthash.subopts[:feature]
-        if !@opthash.subopts[:feature].to_s.include?('.json')
+        if !@opthash.subopts[:feature].to_s.end_with?('json')
           abort("\nERROR: No Feature File specified. Please specify Feature File for creating scenario visualizations.\n")
         end
         run_dir = File.join(@feature_path, 'run')


### PR DESCRIPTION
### Resolves #414 

### Pull Request Description

Be slightly less restrictive when running the `visualize` command to allow filetypes that end with `json` instead of only allowing `json` file type. For instance, now `*.geojson` is allowed.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
