### PR TITLE
error handling for non-US weatherfiles

### DIFF
--- a/example_files/mappers/Baseline.rb
+++ b/example_files/mappers/Baseline.rb
@@ -366,8 +366,8 @@ module URBANopt
         end
 
         # If no match is found, raise an error
-        raise ("Error: No match found for #{wmo} in the weather file #{zones_csv}.
-        This is known to happen when your weather file is from somehwere outside of the United States.
+        raise ("Error: No match found for WMO #{wmo} from your weather file #{Pathname(epw).expand_path} in our US WMO list.
+        This is known to happen when your weather file is from somewhere outside of the United States.
         Please replace your weather file with one from an analagous weather location in the United States.")
       end
 

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -3,6 +3,7 @@
 # See also https://github.com/urbanopt/urbanopt-cli/blob/develop/LICENSE.md
 # *********************************************************************************
 
+require 'csv'
 require 'json'
 
 RSpec.describe URBANopt::CLI do
@@ -33,6 +34,7 @@ RSpec.describe URBANopt::CLI do
   test_feature_rnm = test_directory / 'example_project_with_streets.json'
   test_validate_bounds = test_directory_res / 'out_of_bounds_validation.yaml'
   test_reopt_scenario_assumptions_file = test_directory_pv / 'reopt' / 'multiPV_assumptions.json'
+  test_weather_file = test_directory_res / 'weather' / 'USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw'
   call_cli = 'bundle exec uo'
 
   # Ensure clean slate for testing
@@ -294,15 +296,15 @@ RSpec.describe URBANopt::CLI do
 
   context 'Run and work with a small simulation' do
     before :all do
-      delete_directory_or_file(test_directory)
-      system("#{call_cli} create --project-folder #{test_directory}")
+    #   delete_directory_or_file(test_directory)
+    #   system("#{call_cli} create --project-folder #{test_directory}")
       delete_directory_or_file(test_directory_res)
       system("#{call_cli} create --project-folder #{test_directory_res} --combined")
-      delete_directory_or_file(test_directory_elec)
-      # use this to test both opendss and disco workflows
-      system("#{call_cli} create --project-folder #{test_directory_elec} --disco")
-      delete_directory_or_file(test_directory_pv)
-      system("#{call_cli} create --project-folder #{test_directory_pv} --photovoltaic")
+    #   delete_directory_or_file(test_directory_elec)
+    #   # use this to test both opendss and disco workflows
+    #   system("#{call_cli} create --project-folder #{test_directory_elec} --disco")
+    #   delete_directory_or_file(test_directory_pv)
+    #   system("#{call_cli} create --project-folder #{test_directory_pv} --photovoltaic")
     end
 
     it 'runs a 2 building scenario using default geometry method' do
@@ -401,6 +403,33 @@ RSpec.describe URBANopt::CLI do
       system("#{call_cli} run --scenario #{test_scenario_res} --feature #{test_feature_res}")
       expect((test_directory_res / 'run' / 'two_building_res' / '5' / 'finished.job').exist?).to be true
       expect((test_directory_res / 'run' / 'two_building_res' / '16' / 'finished.job').exist?).to be true
+    end
+
+    it 'returns graceful error message when non-US weather file is provided' do
+      csv_data = CSV.read(test_weather_file)
+      existing_wmo = csv_data[0][5]
+      # Replace the WMO with a non-US WMO (Vancouver, BC)
+      csv_data[0][5] = 718920
+      CSV.open(test_weather_file, 'w') do |csv|
+        csv_data.each do |row|
+          csv << row
+        end
+      end
+
+      # Attempt to run the residential project
+      system("cp #{spec_dir / 'spec_files' / 'two_building_res.csv'} #{test_scenario_res}")
+      expect { system("#{call_cli} run --scenario #{test_scenario_res} --feature #{test_feature_res}") }
+        .to output(a_string_including('This is known to happen when your weather file is from somewhere outside of the United States.'))
+        .to_stdout_from_any_process
+
+      csv_data = CSV.read(test_weather_file)
+      # Restore the original WMO
+      csv_data[0][5] = existing_wmo
+      CSV.open(test_weather_file, 'w') do |csv|
+        csv_data.each do |row|
+          csv << row
+        end
+      end
     end
 
     it 'runs a 2 building scenario using create bar geometry method' do

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -296,15 +296,15 @@ RSpec.describe URBANopt::CLI do
 
   context 'Run and work with a small simulation' do
     before :all do
-    #   delete_directory_or_file(test_directory)
-    #   system("#{call_cli} create --project-folder #{test_directory}")
+      delete_directory_or_file(test_directory)
+      system("#{call_cli} create --project-folder #{test_directory}")
       delete_directory_or_file(test_directory_res)
       system("#{call_cli} create --project-folder #{test_directory_res} --combined")
-    #   delete_directory_or_file(test_directory_elec)
-    #   # use this to test both opendss and disco workflows
-    #   system("#{call_cli} create --project-folder #{test_directory_elec} --disco")
-    #   delete_directory_or_file(test_directory_pv)
-    #   system("#{call_cli} create --project-folder #{test_directory_pv} --photovoltaic")
+      delete_directory_or_file(test_directory_elec)
+      # use this to test both opendss and disco workflows
+      system("#{call_cli} create --project-folder #{test_directory_elec} --disco")
+      delete_directory_or_file(test_directory_pv)
+      system("#{call_cli} create --project-folder #{test_directory_pv} --photovoltaic")
     end
 
     it 'runs a 2 building scenario using default geometry method' do


### PR DESCRIPTION
### Resolves #438 

### Pull Request Description

Raise an informative error if the weatherfile is not able to match to a known climate zone. This happens if a user tries to use a non-US weather file, and may also catch other errors in the weather file.

### Checklist (Delete lines that don't apply)

~- [ ] Unit tests have been added or updated~
- [ ] All ci tests pass (green) (not expected until #442 is merged, which is waiting on ditto-reader PRs [47, 48, & 50](https://github.com/urbanopt/urbanopt-ditto-reader/pulls))
- [x] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
