### PR TITLE
use unsecured http as default rubygems source in project_dir

### DIFF
--- a/example_files/Gemfile
+++ b/example_files/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 ruby '~> 2.7.0'
 


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

Some installations (maybe just Apple Silicon from the installer?) don't allow our bundle to install when using `https://rubygems.org` in the project_dir Gemfile. So we now default to using `http://rubygems.org` which is less secure but actually works.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
