### PR TITLE
Call GMT-cli correctly

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         # os: container operations in GHA only work on Ubuntu
-        simulation-type: [basic, GEB, residential, electric]
-        # python-version: No need to test more than 1 python-version
+        # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
+        simulation-type: [basic, GHE, GEB, residential, electric]
     runs-on: ubuntu-latest
     container:
       image: docker://nrel/openstudio:3.7.0
@@ -34,19 +34,13 @@ jobs:
       - name: Change Owner of Container Working Directory
       # working dir permissions workaround from https://github.com/actions/runner-images/issues/6775#issuecomment-1377299658
         run: chown root:root .
-      - name: Set up Python
-        if: ${{ matrix.simulation-type == 'electric' }}
-        uses: actions/setup-python@v5
-        with:
-          # Disco needs python ~=3.10
-          python-version: '3.10'
       - name: Install Ruby dependencies
         run: |
           ruby --version
           bundle update
           bundle exec certified-update
       - name: Install python dependencies
-        if: ${{ matrix.simulation-type == 'electric' || matrix.simulation-type == 'basic' }}
+        if: ${{ matrix.simulation-type == 'electric' || matrix.simulation-type == 'GHE' }}
         run: bundle exec rspec -e 'Install python dependencies'
       - name: Test project setup
         # We only need to run these tests once, not every matrix iteration.
@@ -68,4 +62,4 @@ jobs:
           name: rspec_results
           path: |
             spec/test_directory**/
-          retention-days: 7 # save for 1 week before deleting
+          retention-days: 7 # save for 1 week then delete

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -376,6 +376,9 @@ module URBANopt
             "Valid choices: 'time_series'", type: String, default: 'time_series'
 
           opt :ghe, "\nUse this argument to add Ground Heat Exchanger properties to the System Parameter File.\n", short: :g
+
+          opt :overwrite, "\n Delete and rebuild existing sys-param file\n", short: :o
+          'Example: uo des_params --sys-param-file path/to/sys_params.json --feature path/to/example_project.json --overwrite'
         end
       end
 
@@ -390,11 +393,10 @@ module URBANopt
             'Example: uo des_create --feature path/to/example_project.json', type: String, required: true, short: :f
 
           opt :des_name, "\nPath to Modelica project dir to be created\n" \
-            'Example: uo des_create --des-name path/to/example_modelica_project', type: String, required: true
+            'Example: uo des_create --des-name path/to/example_modelica_project', type: String, required: true, short: :n
 
-          opt :model_type, "\nSelection for which kind of DES simulation to perform\n" \
-            "Valid choices: 'time_series'", type: String, default: 'time_series'
-
+          opt :overwrite, "\nDelete and rebuild existing model directory\n", short: :o
+            'Example: uo des_create --des-name path/to/example_modelica_project --overwrite'
         end
       end
 
@@ -1758,6 +1760,10 @@ module URBANopt
           end
           des_cli_addition += " --ghe"
         end
+        if @opthash.subopts[:overwrite]
+          puts "\nDeleting and rebuilding existing sys-param file"
+          des_cli_addition += " --overwrite"
+        end
       else
         abort("\nCommand must include new system parameter file name, ScenarioFile, & FeatureFile. Please try again")
       end
@@ -1786,8 +1792,9 @@ module URBANopt
         if @opthash.subopts[:des_name]
           des_cli_addition += " #{File.expand_path(@opthash.subopts[:des_name])}"
         end
-        if @opthash.subopts[:model_type]
-          des_cli_addition += " #{@opthash.subopts[:model_type]}"
+        if @opthash.subopts[:overwrite]
+          puts "\nDeleting and rebuilding existing Modelica dir"
+          des_cli_addition += " --overwrite"
         end
       else
         abort("\nCommand must include system parameter file name, FeatureFile, and model name. Please try again")

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -312,8 +312,6 @@ RSpec.describe URBANopt::CLI do
     before :all do
       delete_directory_or_file(test_directory)
       system("#{call_cli} create --project-folder #{test_directory}")
-      delete_directory_or_file(test_directory_ghe)
-      system("#{call_cli} create --project-folder #{test_directory_ghe} --ghe")
     end
 
     it 'runs a 2 building scenario using default geometry method', :basic do
@@ -405,34 +403,6 @@ RSpec.describe URBANopt::CLI do
       expect((test_directory / 'run' / 'two_building_scenario' / 'feature_file_rnm.json').exist?).to be true
     end
 
-    it 'runs a ghe project', :basic do
-      system("cp #{spec_dir / 'spec_files' / 'baseline_scenario_ghe.csv'} #{test_scenario_ghe}")
-      puts "copied #{test_scenario_ghe}"
-      system("#{call_cli} run --scenario #{test_scenario_ghe} --feature #{test_feature_ghe}")
-      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / '4' / 'finished.job').exist?).to be true
-      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / '5' / 'finished.job').exist?).to be true
-    end
-
-    it 'default post-processes ghe scenario', :basic do
-      # This test requires the 'run ghe project' be run first
-      test_scenario_report = test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'default_scenario_report.csv'
-      system("#{call_cli} process --default --scenario #{test_scenario_ghe} --feature #{test_feature_ghe}")
-      #expect(`wc -l < #{test_scenario_report}`.to_i).to be > 2
-      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'process_status.json').exist?).to be true
-    end
-
-    it 'creates a system parameter file with GHE properties', :basic do
-      system("#{call_cli} des_params --scenario #{test_scenario_ghe} --feature #{test_feature_ghe} --sys-param-file #{ghe_system_parameters_file} --ghe")
-      expect(ghe_system_parameters_file.exist?).to be true
-      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'ghe_dir').exist?).to be true
-    end
-
-    it 'successfully calls the Thermal Network repository for GHE Sizing', :basic do
-      system("#{call_cli} ghe_size --sys-param #{ghe_system_parameters_file} --scenario #{test_scenario_ghe} --feature #{test_feature_ghe}")
-      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'ghe_dir').exist?).to be true
-      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'ghe_dir').empty?).to be false
-    end
-
     it 'saves post-process output as a database file', :basic do
       # This test requires the 'runs a 2 building scenario using default geometry method' be run first
       db_filename = test_directory / 'run' / 'two_building_scenario' / 'default_scenario_report.db'
@@ -480,6 +450,63 @@ RSpec.describe URBANopt::CLI do
       bar_scenario = test_directory / 'two_building_create_bar.csv'
       system("#{call_cli} delete --scenario #{bar_scenario}")
       expect((test_directory / 'run' / 'two_building_create_bar' / '2' / 'data_point_out.json').exist?).to be false
+    end
+  end
+
+  context 'Run and work with a small GHE simulation' do
+    before :all do
+      delete_directory_or_file(test_directory_ghe)
+      system("#{call_cli} create --project-folder #{test_directory_ghe} --ghe")
+    end
+
+    it 'runs a ghe project', :ghe do
+      system("cp #{spec_dir / 'spec_files' / 'baseline_scenario_ghe.csv'} #{test_scenario_ghe}")
+      puts "copied #{test_scenario_ghe}"
+      system("#{call_cli} run --scenario #{test_scenario_ghe} --feature #{test_feature_ghe}")
+      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / '4' / 'finished.job').exist?).to be true
+      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / '5' / 'finished.job').exist?).to be true
+    end
+
+    it 'default post-processes ghe scenario', :ghe do
+      # This test requires the 'run ghe project' be run first
+      test_scenario_report = test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'default_scenario_report.csv'
+      system("#{call_cli} process --default --scenario #{test_scenario_ghe} --feature #{test_feature_ghe}")
+      #expect(`wc -l < #{test_scenario_report}`.to_i).to be > 2
+      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'process_status.json').exist?).to be true
+    end
+
+    it 'creates a system parameter file with GHE properties', :ghe do
+      system("#{call_cli} des_params --scenario #{test_scenario_ghe} --feature #{test_feature_ghe} --sys-param-file #{ghe_system_parameters_file} --ghe")
+      expect(ghe_system_parameters_file.exist?).to be true
+      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'ghe_dir').exist?).to be true
+    end
+
+    it 'overwrites a system parameter file', :ghe do
+      expect(ghe_system_parameters_file.exist?).to be true
+      system("#{call_cli} des_params --scenario #{test_scenario_ghe} --feature #{test_feature_ghe} --sys-param-file #{ghe_system_parameters_file} --ghe --overwrite")
+      expect(ghe_system_parameters_file.exist?).to be true
+      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'ghe_dir').exist?).to be true
+    end
+
+    it 'successfully calls the Thermal Network repository for GHE Sizing', :ghe do
+      system("#{call_cli} ghe_size --sys-param #{ghe_system_parameters_file} --scenario #{test_scenario_ghe} --feature #{test_feature_ghe}")
+      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'ghe_dir').exist?).to be true
+      expect((test_directory_ghe / 'run' / 'baseline_scenario_ghe' / 'ghe_dir').empty?).to be false
+    end
+
+    it 'creates a Modelica model with the GMT', :ghe do
+      system("#{call_cli} des_create --feature #{test_feature_ghe} --sys-param #{ghe_system_parameters_file} --des-name #{test_directory_ghe / 'modelica_ghe'}")
+      expect((test_directory_ghe / 'modelica_ghe'/ 'Districts' / 'DistrictEnergySystem.mo').exist?).to be true
+    end
+
+    it 'overwrites an existing Modelica model', :ghe do
+      system("#{call_cli} des_create --feature #{test_feature_ghe} --sys-param #{ghe_system_parameters_file} --des-name #{test_directory_ghe / 'modelica_ghe'} --overwrite")
+      expect((test_directory_ghe / 'modelica_ghe'/ 'Districts' / 'DistrictEnergySystem.mo').exist?).to be true
+    end
+
+    it 'runs a Modelica simulation with the GMT', :ghe do
+      system("#{call_cli} des_run --model #{test_directory_ghe / 'modelica_ghe'}")
+      expect((test_directory_ghe / 'modelica_ghe'/ 'modelica_ghe.Districts.DistrictEnergySystem_results' / 'modelica_ghe.Districts.DistrictEnergySystem_res.mat').exist?).to be true
     end
   end
 

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -324,6 +324,7 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'creates a system parameter file', :basic do
+      skip('Requires Python 3.10') unless system('python3 --version') =~ /3\.10/
       system("#{call_cli} des_params --scenario #{test_scenario} --feature #{test_feature} --sys-param-file #{system_parameters_file}")
       expect(system_parameters_file.exist?).to be true
     end

--- a/spec/uo_cli_spec.rb
+++ b/spec/uo_cli_spec.rb
@@ -505,6 +505,7 @@ RSpec.describe URBANopt::CLI do
     end
 
     it 'runs a Modelica simulation with the GMT', :ghe do
+      skip('Requires Docker to be installed') unless system('which docker > /dev/null 2>&1')
       system("#{call_cli} des_run --model #{test_directory_ghe / 'modelica_ghe'}")
       expect((test_directory_ghe / 'modelica_ghe'/ 'modelica_ghe.Districts.DistrictEnergySystem_results' / 'modelica_ghe.Districts.DistrictEnergySystem_res.mat').exist?).to be true
     end


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

- We weren't calling the GMT-cli correctly which led to an erroneous error message when trying to `uo create_model`.
- The GMT-cli now works as intended, so we need tests for it! I made some.
- Added a new category of tests in CI to keep the parallelization going strong

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
