### PR TITLE
Install exact python dependency versions, and bump ThermalNetwork version

### DIFF
--- a/example_files/python_deps/dependencies.json
+++ b/example_files/python_deps/dependencies.json
@@ -1,5 +1,5 @@
 [
-  { "name": "ThermalNetwork", "version": "0.2.3"},
+  { "name": "ThermalNetwork", "version": "0.2.4"},
   { "name": "urbanopt-ditto-reader", "version": "0.6.3"},
   { "name": "NREL-disco", "version": "0.5.0"},
   { "name": "geojson-modelica-translator", "version": "0.6.0"}

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -1121,7 +1121,7 @@ module URBANopt
           if dep[:version].nil?
             the_command = "#{pvars[:pip_path]} install #{dep[:name]}"
           else
-            the_command = "#{pvars[:pip_path]} install #{dep[:name]}~=#{dep[:version]}"
+            the_command = "#{pvars[:pip_path]} install #{dep[:name]}==#{dep[:version]}"
           end
 
           if @opthash.subopts[:verbose]


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

ThermalNetwork version has been updated. We grab the newest patch version when we install, because we use tilde-version [here](https://github.com/urbanopt/urbanopt-cli/blob/develop/lib/uo_cli.rb#L1124). However, [this if statement](https://github.com/urbanopt/urbanopt-cli/blob/develop/lib/uo_cli.rb#L999-L1009) wants the version to match exactly, including patch version, so we output the "incorrect version" message. In this case, that's an erroneous message, but perhaps not always? During heavy development, I can imagine that sometimes the patch level could contain breaking changes. Or should we change the logic for that incorrect version message?

Decided to install exact dependency versions to eliminate this problem. In the distant future when versions are more stable we can revisit this.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
