### PR TITLE
Upgrade miniconda

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   weeknight-tests:
     strategy:
+      fail-fast: false
       matrix:
         # os: container operations in GHA only work on Ubuntu
         # https://docs.github.com/en/actions/using-containerized-services/about-service-containers

--- a/example_files/python_deps/dependencies.json
+++ b/example_files/python_deps/dependencies.json
@@ -1,5 +1,5 @@
 [
-  { "name": "ThermalNetwork", "version": "0.2.5"},
+  { "name": "ThermalNetwork", "version": "0.3.0"},
   { "name": "urbanopt-ditto-reader", "version": "0.6.4"},
   { "name": "NREL-disco", "version": "0.5.1"},
   { "name": "geojson-modelica-translator", "version": "0.8.0"}

--- a/example_files/python_deps/install_python.sh
+++ b/example_files/python_deps/install_python.sh
@@ -77,13 +77,29 @@ if [ ! -d $INSTALL_BASE ]; then
 	exit 1
 fi
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-	PLATFORM=Linux-x86_64
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-	PLATFORM=MacOSX-x86_64
-else
-	error "unknown OS type $OSTYPE"
-	exit 1
+architecture=$(uname -m)
+
+echo "$architecture"
+
+# Handle multiple chip architectures (ARM & x86) as well as OS types (Linux & MacOS)
+if [[ $architecture == "x86"* || $architecture == "i686" || $architecture == "i386" ]]; then
+	if [[ "$OSTYPE" == "linux-gnu" ]]; then
+		PLATFORM=Linux-x86_64
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
+		PLATFORM=MacOSX-x86_64
+	else
+		error "unknown OS type $OSTYPE"
+		exit 1
+	fi
+elif [[ $architecture == "arm"* || $architecture == "aarch"* ]]; then
+	if [[ "$OSTYPE" == "linux-gnu" ]]; then
+		PLATFORM=Linux-aarch64
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
+		PLATFORM=MacOSX-arm64
+	else
+		error "unknown OS type $OSTYPE"
+		exit 1
+	fi
 fi
 
 CONDA_PACKAGE_NAME=Miniconda3-py${PYTHON_MAJOR_MINOR}_${CONDA_VERSION}-${PLATFORM}.sh

--- a/lib/uo_cli.rb
+++ b/lib/uo_cli.rb
@@ -905,7 +905,7 @@ module URBANopt
     def self.setup_python_variables
       pvars = {
         python_version: '3.10',
-        miniconda_version: '4.12.0',
+        miniconda_version: '24.9.2-0',
         python_install_path: nil,
         python_path: nil,
         pip_path: nil,


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

- Use a new version of miniconda. The previous version had an older version of `pip` included which couldn't handle new python packaging standards. This resolves that issue.
- Use a new version of ThermalNetwork, to resolve the failing tests.

Since we set up miniconda, they have switched to date-version format, instead of semantic-version.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-cli/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
