### PR TITLE
Update reopt assumptions file to work with REopt-api v3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## Version 1.0.0
+## Version 1.0.1
 
 ## What's Changed
 
-- Update to support ruby 3.2.2 and OpenStudio 3.9.0
+* Update reopt assumptions file to work with REopt-api v3.11 by @vtnate in https://github.com/urbanopt/urbanopt-cli/pull/504
+
+**Full Changelog**: https://github.com/urbanopt/urbanopt-cli/compare/v1.0.0...v1.0.1
+
+## Version 1.0.0
+
+* Update to support ruby 3.2.2 and OpenStudio 3.9.0
 
 **Full Changelog**: https://github.com/urbanopt/urbanopt-cli/compare/v0.14.0...v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,29 @@
 # Changelog
 
+## Version 1.0.0
+
+## What's Changed
+
+- Update to support ruby 3.2.2 and OpenStudio 3.9.0
+
+**Full Changelog**: https://github.com/urbanopt/urbanopt-cli/compare/v0.14.0...v1.0.0
+
 ## Version 0.14.0
 Date Range: 06/27/2024 - 11/15/2024
 
 ## What's Changed
+
 ### Exciting New Features 🎉
+
 * Upgrade version of ThermalNetwork Python dependency by @vtnate in https://github.com/urbanopt/urbanopt-cli/pull/493
 * Upgrade miniconda by @vtnate in https://github.com/urbanopt/urbanopt-cli/pull/492
 * Use new version of GMT by @vtnate in https://github.com/urbanopt/urbanopt-cli/pull/489
+
 ### Other Changes
+
 * Update installer patch by @tijcolem in https://github.com/urbanopt/urbanopt-cli/pull/476
 * Fix installer path bug by @vtnate in https://github.com/urbanopt/urbanopt-cli/pull/485
 * Remove unnecessary default user-entry for DES commands by @vtnate in https://github.com/urbanopt/urbanopt-cli/pull/486
-
 
 **Full Changelog**: https://github.com/urbanopt/urbanopt-cli/compare/v0.13.0...v0.14.0
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-URBANopt (tm), Copyright (c) 2019-2024, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+URBANopt (tm), Copyright (c) 2019-2025, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/example_files/reopt/base_assumptions.json
+++ b/example_files/reopt/base_assumptions.json
@@ -27,6 +27,7 @@
     "net_metering_limit_kw": 0.0
   },
   "ElectricLoad": {
+    "year": 2017,
     "critical_loads_kw_is_net": false,
     "critical_load_fraction": 0,
     "loads_kw_is_net": true

--- a/example_files/reopt/multiPV_assumptions.json
+++ b/example_files/reopt/multiPV_assumptions.json
@@ -27,7 +27,7 @@
     "net_metering_limit_kw": 0.0
   },
   "ElectricLoad": {
-    "year": 2018,
+    "year": 2017,
     "critical_loads_kw_is_net": false,
     "critical_load_fraction": 0,
     "loads_kw_is_net": true

--- a/lib/uo_cli/version.rb
+++ b/lib/uo_cli/version.rb
@@ -5,6 +5,6 @@
 
 module URBANopt
   module CLI
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.1'.freeze
   end
 end

--- a/spec/spec_files/reopt/base_assumptions.json
+++ b/spec/spec_files/reopt/base_assumptions.json
@@ -27,6 +27,7 @@
     "net_metering_limit_kw": 0.0
   },
   "ElectricLoad": {
+    "year": 2017,
     "critical_loads_kw_is_net": false,
     "critical_load_fraction": 0,
     "loads_kw_is_net": true

--- a/spec/spec_files/reopt/multiPV_assumptions.json
+++ b/spec/spec_files/reopt/multiPV_assumptions.json
@@ -27,7 +27,7 @@
     "net_metering_limit_kw": 0.0
   },
   "ElectricLoad": {
-    "year": 2018,
+    "year": 2017,
     "critical_loads_kw_is_net": false,
     "critical_load_fraction": 0,
     "loads_kw_is_net": true


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

Reopt-api v3.11 contained a new requirement for the `year` field to be included in `ElectricLoad`. We addressed that in the reopt-gem with https://github.com/urbanopt/urbanopt-reopt-gem/pull/157, but mistakenly didn't make the same change here. This fixes that.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [x] This PR has been labeled appropriately (which will be used for the changelog)
- [x] This branch is up-to-date with develop
