### PR TITLE
add modelica exports measure to residential features

### DIFF
--- a/example_files/mappers/Baseline.rb
+++ b/example_files/mappers/Baseline.rb
@@ -666,6 +666,10 @@ module URBANopt
               OpenStudio::Extension.set_measure_argument(osw, 'BuildResidentialModel', arg_name, args[arg_name])
             end
 
+            # Ensure residential runs also generate Modelica exports used by DES post-processing.
+            OpenStudio::Extension.set_measure_argument(osw, 'export_time_series_modelica', '__SKIP__', false)
+            OpenStudio::Extension.set_measure_argument(osw, 'export_modelica_loads', '__SKIP__', false)
+
           elsif commercial_building_types.include? building_type
             # set_run_period
             OpenStudio::Extension.set_measure_argument(osw, 'set_run_period', '__SKIP__', false)


### PR DESCRIPTION
export_time_series_modelica and export_modelica_loads measures were skipped on residential features. Ensure that they are added to account for them in the DES post-processing.